### PR TITLE
Add "-sdk" in dapr.yaml snippet to match code

### DIFF
--- a/dapr-101/5-pubsub-api/assignment.md
+++ b/dapr-101/5-pubsub-api/assignment.md
@@ -17,7 +17,7 @@ version: 1
 common:
   resourcesPath: ../../components/
 apps:
-  - appID: order-processor
+  - appID: order-processor-sdk
     appDirPath: ./order-processor/
     appPort: 7006
     command: ["dotnet", "run"]


### PR DESCRIPTION
The dapr.yaml file in the code includes "-sdk" at the end of the appID name for both order-processort-sdk and checkout-sdk.