### PR TITLE
docs: add baseline README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,26 @@
 # Dapr University Tracks
 
-This repo contains content and configuration for the Dapr University tracks hosted with Instruqt.
+This repo contains content and configuration for the Dapr University tracks hosted with Instruqt. Each track is a self-paced, browser-based learning experience that teaches a specific area of Dapr (workflow, agents, .NET Aspire integration, Catalyst, and Dapr fundamentals) through hands-on challenges. The repository is the source of truth for the track definitions, challenge instructions, setup scripts, and assignment code that Instruqt renders for learners.
 
 You can access the Dapr University lessons here: https://www.diagrid.io/dapr-university
+
+## Prerequisites
+
+The tracks are designed to be consumed through the [Dapr University](https://www.diagrid.io/dapr-university) site — no local installation is required by learners. To preview or edit a track locally you need an [Instruqt](https://instruqt.com/) account with access to the track configuration.
+
+## Running the tracks
+
+The tracks are not intended to be run locally — they are hosted on Instruqt and launched from [Dapr University](https://www.diagrid.io/dapr-university). To make changes, edit the track folder in this repo and push to the relevant Instruqt track.
+
+## Project structure
+
+- `dapr-101/` — Introductory Dapr track.
+- `dapr-workflow/` — Dapr Workflow track (durable execution, task chaining, fan-out/fan-in, monitor, external events, child workflows, resiliency, workflow management).
+- `dapr-workflow-aspire/` — Dapr Workflow with .NET Aspire track.
+- `dapr-dotnet-aspire/` — Dapr + .NET Aspire integration track.
+- `dapr-agents/` — Dapr Agents track.
+- `catalyst-101/` — Introductory Diagrid Catalyst track.
+
+---
+
+Join the [Dapr Discord](https://diagrid.ws/dapr-discord) for Q&A and chat with other community members!


### PR DESCRIPTION
Brings README up to the diagrid-labs baseline: expanded purpose, prerequisites framed for Instruqt-hosted tracks, project structure listing all six tracks, Discord CTA.