### PR TITLE
Add AI agents deep investigation track

### DIFF
--- a/ai-agents-deepagents/1-introduction/assignment.md
+++ b/ai-agents-deepagents/1-introduction/assignment.md
@@ -1,0 +1,78 @@
+Welcome to **Deep Issue Investigation that Survives the Long Haul**. In this track you'll build a CLI tool that points a [DeepAgents](https://docs.langchain.com/oss/python/deepagents) agent at a real, gnarly GitHub issue and has it write an investigation report — then make that investigation durable enough to survive a crash.
+
+In this first challenge you'll set up the sandbox environment and get the CLI tool running against a sample issue. This challenge takes about 5 minutes to complete.
+
+## What is DeepAgents?
+
+DeepAgents is a framework, built on [LangGraph](https://www.langchain.com/langgraph), that gives an LLM three things a plain chat loop doesn't have:
+
+- **Planning** — the agent breaks a vague instruction ("investigate this issue") into its own steps before acting.
+- **Tools** — functions the agent can call to read data (in our case, a local GitHub snapshot — never the live API).
+- **A virtual filesystem** — a scratchpad the agent reads and writes to as it works, including the final report.
+
+## Why durability matters
+
+A real investigation isn't one LLM call — it's dozens of tool calls and reasoning steps, and it can take minutes. All of that lives in memory by default. Kill the process at step 30 of 40 and you lose everything: the scratchpad, the partial report, and every dollar spent on LLM calls so far.
+
+In challenges 3 and 4 you'll back that scratchpad with a **Dapr state store** and wrap the run in a **Dapr Workflow**, so a crashed investigation resumes exactly where it left off instead of starting over.
+
+## The target issue
+
+We've picked one issue for this whole track: [dapr/dapr#1833](https://github.com/dapr/dapr/issues/1833) — "Data corruption in actor/service invocation under high rps." It's closed, has real comment threads, and was fixed by a real pull request. You won't choose an issue yourself — every challenge investigates #1833.
+
+## 1. Verify the sandbox
+
+Use the **Terminal** window to confirm the Dapr CLI and runtime are ready:
+
+```bash,run
+dapr -v
+```
+
+> [!NOTE]
+> You should see both a **CLI version** and a **Runtime version** listed. If the Runtime version is blank, run `dapr init` below to initialize it. If you run into any other blocking issue during this course, send me [an email](mailto:marc@diagrid.io), and we'll figure it out together.
+
+```bash,run
+dapr init
+```
+In the *Editor* tab, open `track-data-real/dapr/dapr` to browse the snapshot, then open `manifest.json` to see its contents.
+
+This is a static snapshot of issues and pull requests from the real dapr/dapr repository, collected once and checked into this track. The agent only ever reads from this local snapshot.
+```text,nocopy
+{
+  "schema_version": 1,
+  "owner": "dapr",
+  "repo": "dapr",
+  ...
+  "seed_issues": [
+    1833
+  ],
+  "counts": {
+    "issues": 100,
+    "prs": 50
+  }
+}
+```
+`seed_issues` confirms #1833 is in the snapshot. `counts` tells you how much data was collected around it.
+
+## 2. Add your OpenAI API key
+
+Create a `.env` file in the project directory:
+
+```bash,run,copy
+touch .env
+```
+> [!IMPORTANT]
+> Refresh the 'Editor' tab, so it detects the newly created file. You'll find the arrow on the right side of the tree view labelled DEEP-INVESTIGATION.
+
+Open it in the **Editor** and add your key:
+
+```env,copy
+OPENAI_API_KEY=your_key_here
+```
+
+> [!NOTE]
+> You'll need a real key from https://platform.openai.com/signup as the agent calls `gpt-4o-mini` in every challenge from here on.
+
+---
+
+You now have a working sandbox and a local GitHub snapshot ready for investigation. Let's move on to challenge 2 where you'll run the agent for the first time.

--- a/ai-agents-deepagents/1-introduction/notes.md
+++ b/ai-agents-deepagents/1-introduction/notes.md
@@ -1,0 +1,18 @@
+Click the *Start* button to setup the sandbox environment for this training, this may take up to 2 minutes. Once the environment is ready, click the *Start* button again.
+
+- There are 3 challenges to complete, each takes about 5-10 minutes. If your session is idle for more than 10 minutes, the session will stop and you'll need to restart the track.
+
+---
+
+DeepAgents lets you build an AI agent that can plan, use tools, and take notes as it works. It's how you get real, multi-step investigations out of an LLM instead of a single guess. The challenge will take about 5 minutes.
+
+There's a catch though. If a long-running agent crashes halfway, you lose all its progress and pay for every model call again. The rest of this track shows how Dapr fixes that.
+
+The sandbox for this challenge is being prepared, it should be ready within a few seconds. Once it's ready, click the 'Start' button.
+
+### What you'll learn in this challenge
+
+- What DeepAgents actually is, and why long-running agents are useful
+- Why crashes are such a painful problem for these agents
+- How to confirm your sandbox is ready to go
+- Where the pre-loaded issue data lives

--- a/ai-agents-deepagents/1-introduction/scripts/setup.sh
+++ b/ai-agents-deepagents/1-introduction/scripts/setup.sh
@@ -1,0 +1,7 @@
+git clone https://github.com/diagrid-labs/ai-agent-tracks-instruqt.git
+
+cd ai-agent-tracks-instruqt/deepagents/deep-investigation
+
+cat > .env << 'EOF'
+OPENAI_API_KEY=your_key_here
+EOF

--- a/ai-agents-deepagents/1-introduction/tabs.md
+++ b/ai-agents-deepagents/1-introduction/tabs.md
@@ -1,0 +1,13 @@
+# Tab configuration
+
+## Editor
+
+type: code editor
+host: {{...}}
+path: ai-agent-tracks-instruqt/deepagents/deep-investigation
+
+## Terminal
+
+type: terminal
+host: {{...}}
+path: ai-agent-tracks-instruqt/deepagents/deep-investigation

--- a/ai-agents-deepagents/2-build-the-agent/assignment.md
+++ b/ai-agents-deepagents/2-build-the-agent/assignment.md
@@ -1,0 +1,59 @@
+The sandbox for this challenge is being prepared, it should be ready within a few seconds. Once it's ready, click the Start button.
+
+---
+
+In this challenge you'll run a DeepAgent that investigates a real, closed Dapr bug — [dapr/dapr#1833](https://github.com/dapr/dapr/issues/1833), "Data corruption in actor/service invocation under high rps". Our agent will write its findings to a Markdown report.This challenge takes about 5 minutes to complete.
+
+## 1. Inspect the agent
+
+Open `investigate-baseline.py` in the **Editor** window. It's the baseline version; an in-process DeepAgent, no Dapr yet. Look at the `create_deep_agent(...)` call:
+
+```python,nocopy
+agent = create_deep_agent(
+    model="openai:gpt-4o-mini",
+    tools=TOOLS,
+    system_prompt=SYSTEM_PROMPT,
+    name="issue-investigator",
+)
+```
+
+`TOOLS` comes from `tools.py` — four functions the agent can call:
+
+- `get_issue(number)` — title, state, labels, body of an issue or PR
+- `list_linked_prs(issue_number)` — PRs linked to an issue
+- `get_comments(number)` — all comments on an issue or PR
+- `search_related_issues(query)` — keyword search across the local snapshot
+
+Every one of these reads from a local JSON file under `/opt/track-data` (see `github_data.py`) — **never** the live GitHub API. The snapshot was collected once, at sandbox-image build time.
+
+`SYSTEM_PROMPT` tells the agent to read the issue and its comments, follow any linked PRs, search for related issues, then write `investigation-<issue-number>.md` using its built-in `write_file` tool — part of the virtual filesystem every DeepAgent gets for free.
+
+## 2. Run the investigation
+
+Use the **Terminal** window to run the agent:
+
+```bash,run
+uv run python investigate-baseline.py --issue 1833
+```
+
+Watch the terminal: the agent plans its approach, calls tools one at a time, and reasons about what it finds before writing the report. This whole run lives in your terminal's memory — kill the process now and all of that work is gone.
+
+## 3. Read the report
+
+Refresh the *Editor* tab, then navigate to `investigation-1833.md` to open it.
+
+You should see a **Summary**, **Probable Root Cause**, **Related Work**, and **Suggested Next Steps** — built from the issue body, its comments, and the PR that actually fixed it.
+
+## 4. How this works
+
+1. `create_deep_agent()` builds a LangGraph state machine with a planning node, tool-execution nodes, and a virtual filesystem node.
+2. The agent receives the investigation prompt and decides which tools to call and in what order.
+3. Each tool reads from the local JSON snapshot — no network calls to GitHub.
+4. After gathering enough context, the agent calls `write_file` to persist the report into its virtual filesystem, which is then extracted and written to disk.
+
+> [!NOTE]
+> This run is entirely in-process — there is no Dapr involved yet. Kill the process partway through and everything is lost. That's the problem challenges 3 and 4 solve.
+
+---
+
+You've now run the DeepAgent and seen it produce a real investigation report. Let's move on to challenge 3 where you'll make the same agent durable by wrapping it in a Dapr Workflow.

--- a/ai-agents-deepagents/2-build-the-agent/notes.md
+++ b/ai-agents-deepagents/2-build-the-agent/notes.md
@@ -1,0 +1,14 @@
+Time to run your first investigation. You'll point a DeepAgent at issue in `dapr/dapr` repository. Its a real closed bug with plenty of threads to pull on. The challenge will take about 5 minutes.
+
+The agent reads from a local copy of the issue and its comments, so nothing hits GitHub live. It'll plan its own approach, call its tools, and write up what it finds in a file.
+
+It works. But it's all happening in memory. If anything crashes, it's gone. That's what we fix next.
+
+The sandbox for this challenge is being prepared, it should be ready within a few seconds. Once it's ready, click the 'Start' button.
+
+### What you'll learn in this challenge
+
+- How to run a DeepAgent from the command line
+- What it looks like when an agent plans and calls tools on its own
+- Where the finished investigation report ends up
+- Why running it all in memory is a problem

--- a/ai-agents-deepagents/2-build-the-agent/tabs.md
+++ b/ai-agents-deepagents/2-build-the-agent/tabs.md
@@ -1,0 +1,13 @@
+# Tab configuration
+
+## Editor
+
+type: code editor
+host: {{...}}
+path: ai-agent-tracks-instruqt/deepagents/deep-investigation
+
+## Terminal
+
+type: terminal
+host: {{...}}
+path: ai-agent-tracks-instruqt/deepagents/deep-investigation

--- a/ai-agents-deepagents/3-crash-the-agent/assignment.md
+++ b/ai-agents-deepagents/3-crash-the-agent/assignment.md
@@ -1,0 +1,87 @@
+The sandbox for this challenge is being prepared, it should be ready within a few seconds. Once it's ready, click the Start button.
+
+---
+
+This is the payoff. You're going to crash the investigation on purpose, then prove the workflow picks up exactly where it left off. This challenge takes about 5 minutes to complete.
+
+## 1. Find the crash line
+
+Open `tools_crash.py` in the **Editor**. This is the same `get_comments` tool as before, with one line added — **line 34**:
+
+```python,nocopy
+os._exit(1)  # Simulates a crash — comment out this line before the second run
+```
+
+`investigate-crash.py` imports tools from `tools_crash.py`. `os._exit(1)` kills the Python process immediately — no exception, no cleanup, no chance for Dapr to gracefully shut down. This simulates a hard infrastructure failure: a pod eviction, an OOM kill, a host reboot.
+
+The script also uses a `crash_state.json` file to persist the Dapr workflow ID across restarts. On the first run it writes this file when the `workflow_started` event fires; on the second run it detects the file and polls the **existing** workflow rather than starting a new one.
+
+## 2. Trigger the crash
+
+Use the **Terminal** window to start the investigation:
+
+```bash,run
+uv run dapr run --app-id deepagent --resources-path ./resources -- python investigate-crash.py --issue 1833
+```
+
+Watch the terminal. The agent calls `get_issue` first — that activity completes and gets checkpointed. The workflow ID is saved to `crash_state.json`. Then the agent calls `get_comments`, and the process dies. The terminal output stops; there is no graceful shutdown message.
+
+Verify the crash was recorded:
+
+```bash,run
+cat crash_state.json
+```
+
+```text,nocopy
+{
+  "workflow_scheduled": true,
+  "workflow_id": "graph-investigation-1833-<uuid>",
+  "run_count": 1
+}
+```
+
+> [!NOTE]
+> The `workflow_id` is the handle to the in-flight Dapr workflow. The script uses it on the next run to reconnect to the same instance rather than starting a new one.
+
+## 3. Remove the crash
+
+Back in the **Editor**, comment out line 34 in `tools_crash.py`:
+
+```python,nocopy
+# os._exit(1)  # Simulates a crash — comment out this line before the second run
+```
+
+## 4. Run again — watch the recovery
+
+Use the **Terminal** window to restart the investigation:
+
+```bash,run
+uv run dapr run --app-id deepagent --resources-path ./resources -- python investigate-crash.py --issue 1833
+```
+
+Watch closely: the script detects `crash_state.json`, skips `run_async()`, and polls the **same** workflow instance by its saved ID. The Dapr Workflow engine replays history up to the last checkpoint and continues execution from `get_comments` — `get_issue` is **not** called again. Execution continues from where it crashed, and the investigation completes.
+
+> [!IMPORTANT]
+> The key proof is in the logs: you will not see `get_issue` being executed again. Dapr's replay mechanism skips any activity whose result is already in the checkpoint store.
+
+## 5. Read the report
+
+```bash,run
+cat investigation-1833.md
+```
+
+A complete report, even though the process that produced it died and restarted halfway through.
+
+## 6. How this works
+
+1. On the first run, `run_async()` starts a new Dapr Workflow and saves the workflow ID to `crash_state.json` when `workflow_started` fires.
+2. `os._exit(1)` kills the process hard — the activity result for `get_comments` is not written, but `get_issue`'s result is already in Redis.
+3. On the second run, the script detects `crash_state.json` and skips `run_async()`. Instead it calls `poll_for_completion()` using the saved workflow ID.
+4. Dapr reconnects to the existing workflow instance, replays checkpointed activities (returning their saved results without re-executing them), and resumes at `get_comments`.
+5. The investigation completes and `investigation-1833.md` is written to disk.
+
+That's the entire point of backing a long-running agent with Dapr: a crash costs you a restart, not the work.
+
+---
+
+You've completed the track. From here you could add sub-agents for parallel investigation, point the same pattern at a different issue, or wire in Dapr's Conversation API for additional LLM-call resiliency.

--- a/ai-agents-deepagents/3-crash-the-agent/tabs.md
+++ b/ai-agents-deepagents/3-crash-the-agent/tabs.md
@@ -1,0 +1,13 @@
+# Tab configuration
+
+## Editor
+
+type: code editor
+host: {{...}}
+path: ai-agent-tracks-instruqt/deepagents/deep-investigation
+
+## Terminal
+
+type: terminal
+host: {{...}}
+path: ai-agent-tracks-instruqt/deepagents/deep-investigation

--- a/ai-agents-deepagents/4-make-it-durable/assignment.md
+++ b/ai-agents-deepagents/4-make-it-durable/assignment.md
@@ -1,0 +1,76 @@
+The sandbox for this challenge is being prepared, it should be ready within a few seconds. Once it's ready, click the Start button.
+
+---
+
+The baseline agent worked, but everything it did lived in process memory. In this challenge you'll wrap the exact same agent in a **Dapr Workflow**, so its scratchpad and progress are persisted as it runs. This challenge takes about 5 minutes to complete.
+
+## 1. Inspect the durable version
+
+Open investigate-durable.py in the **Editor**. The agent definition is unchanged — same tools, same system prompt. What's new is the entry point:
+
+```python,nocopy
+from diagrid.agent.deepagents import DaprWorkflowDeepAgentRunner
+
+runner = DaprWorkflowDeepAgentRunner(
+    agent=agent,
+    name="issue-investigation",
+    max_steps=50,
+)
+```
+
+Instead of `agent.invoke(...)`, the script now calls `runner.start()` and streams events from `runner.run_async(...)`. Under the hood, every tool call the agent makes becomes a **Dapr Workflow activity** — and Dapr checkpoints each activity's result before moving to the next one.
+
+## 2. Inspect the state store
+
+Open `resources/statestore.yaml` in the **Editor**:
+
+```yaml,nocopy
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: agent-memory
+spec:
+  type: state.redis
+  version: v1
+  metadata:
+    - name: redisHost
+      value: localhost:6379
+    - name: redisPassword
+      value: ""
+    - name: actorStateStore
+      value: "true"
+```
+
+This is a Redis-backed Dapr state store named `agent-memory` — the name the DeepAgents Dapr integration looks for by convention. `actorStateStore: "true"` means it also backs the Dapr Workflow engine itself (workflows run on Dapr's actor runtime under the hood).
+
+## 3. Run the durable investigation
+
+Use the **Terminal** window to run the agent with Dapr:
+
+```bash,run
+uv run dapr run --app-id deepagent --resources-path ./resources -- python investigate-durable.py --issue 1833
+```
+
+Watch the terminal — you'll see the same tool calls as challenge 2, but now interleaved with `Event: workflow_started`, `Event: workflow_status_changed`, and `Event: workflow_completed` as Dapr tracks the run.
+
+## 4. Read the report
+
+```bash,run
+cat investigation-1833.md
+```
+
+Same report quality as challenge 2 — but this time, if the process had died halfway through, the work up to that point wouldn't be lost. That's exactly what you'll prove next.
+
+## 5. How this works
+
+1. `DaprWorkflowDeepAgentRunner.start()` registers the agent graph as a Dapr Workflow and starts the actor runtime.
+2. Each node in the LangGraph state machine (tool call, model call, middleware) is wrapped as a Dapr Workflow activity.
+3. Before Dapr moves to the next activity, it writes the result of the current one to the Redis state store.
+4. If the process dies, the workflow engine can replay history up to the last checkpoint and resume from there on restart.
+
+> [!IMPORTANT]
+> Use `Ctrl+C` in the **Terminal** window to stop the Dapr application before moving on.
+
+---
+
+You've now run the same investigation backed by a Dapr Workflow, with every step checkpointed to Redis. Let's move on to challenge 4 where you'll prove this works by intentionally crashing the process mid-investigation.

--- a/ai-agents-deepagents/4-make-it-durable/notes.md
+++ b/ai-agents-deepagents/4-make-it-durable/notes.md
@@ -1,0 +1,14 @@
+Same investigation, but now Dapr is saving the agent's work as it goes. The challenge will take about 5 minutes.
+
+Instead of the agent keeping its notes in memory, every step gets saved to a Redis state store. After the run, you can peek into the actual saved state through the terminal — proof it's not just floating in the process anymore.
+
+This is the setup for the crash recovery in the next challenge.
+
+The sandbox for this challenge is being prepared, it should be ready within a few seconds. Once it's ready, click the 'Start' button.
+
+### What you'll learn in this challenge
+
+- How to swap in-memory state for durable state with Dapr
+- What a Dapr state store component looks like
+- How to check the saved state directly in Redis
+- Why this small change makes crash recovery possible

--- a/ai-agents-deepagents/4-make-it-durable/tabs.md
+++ b/ai-agents-deepagents/4-make-it-durable/tabs.md
@@ -1,0 +1,13 @@
+# Tab configuration
+
+## Editor
+
+type: code editor
+host: {{...}}
+path: ai-agent-tracks-instruqt/deepagents/deep-investigation
+
+## Terminal
+
+type: terminal
+host: {{...}}
+path: ai-agent-tracks-instruqt/deepagents/deep-investigation

--- a/ai-agents-deepagents/build-the-agent/assignment.md
+++ b/ai-agents-deepagents/build-the-agent/assignment.md
@@ -1,0 +1,65 @@
+In this challenge you'll run a DeepAgent that investigates a real, closed Dapr bug — [dapr/dapr#1833](https://github.com/dapr/dapr/issues/1833), "Data corruption in actor/service invocation under high rps". Our agent will write its findings to a Markdown report.
+
+## 1. Add your API key
+
+Open the `.env` file in the **Editor** and replace the placeholder:
+
+```env,nocopy
+OPENAI_API_KEY=your_key_here
+```
+
+## 2. Inspect the agent
+
+Open `investigate.py` in the **Editor** window. It's the baseline version; an in-process DeepAgent, no Dapr yet. Look at the `create_deep_agent(...)` call:
+
+```python,nocopy
+agent = create_deep_agent(
+    model="openai:gpt-4o-mini",
+    tools=TOOLS,
+    system_prompt=SYSTEM_PROMPT,
+    name="issue-investigator",
+)
+```
+
+`TOOLS` comes from `tools.py` — four functions the agent can call:
+
+- `get_issue(number)` — title, state, labels, body of an issue or PR
+- `list_linked_prs(issue_number)` — PRs linked to an issue
+- `get_comments(number)` — all comments on an issue or PR
+- `search_related_issues(query)` — keyword search across the local snapshot
+
+Every one of these reads from a local JSON file under `/opt/track-data` (see `github_data.py`) — **never** the live GitHub API. The snapshot was collected once, at sandbox-image build time.
+
+`SYSTEM_PROMPT` tells the agent to read the issue and its comments, follow any linked PRs, search for related issues, then write `investigation-<issue-number>.md` using its built-in `write_file` tool — part of the virtual filesystem every DeepAgent gets for free.
+
+## 3. Run the investigation
+
+Use the **Terminal** window to run the agent:
+
+```bash,run
+uv run python investigate.py --issue 1833
+```
+
+Watch the terminal: the agent plans its approach, calls tools one at a time, and reasons about what it finds before writing the report. This whole run lives in your terminal's memory — kill the process now and all of that work is gone.
+
+## 4. Read the report
+
+```bash,run
+cat investigation-1833.md
+```
+
+You should see a **Summary**, **Probable Root Cause**, **Related Work**, and **Suggested Next Steps** — built from the issue body, its comments, and the PR that actually fixed it.
+
+## 5. How this works
+
+1. `create_deep_agent()` builds a LangGraph state machine with a planning node, tool-execution nodes, and a virtual filesystem node.
+2. The agent receives the investigation prompt and decides which tools to call and in what order.
+3. Each tool reads from the local JSON snapshot — no network calls to GitHub.
+4. After gathering enough context, the agent calls `write_file` to persist the report into its virtual filesystem, which is then extracted and written to disk.
+
+> [!NOTE]
+> This run is entirely in-process — there is no Dapr involved yet. Kill the process partway through and everything is lost. That's the problem challenges 3 and 4 solve.
+
+---
+
+You've now run the DeepAgent and seen it produce a real investigation report. Let's move on to challenge 3 where you'll make the same agent durable by wrapping it in a Dapr Workflow.

--- a/ai-agents-deepagents/build-the-agent/notes.md
+++ b/ai-agents-deepagents/build-the-agent/notes.md
@@ -1,0 +1,14 @@
+Time to run your first investigation. You'll point a DeepAgent at issue in `dapr/dapr` repository. Its a real closed bug with plenty of threads to pull on. The challenge will take about 5 minutes.
+
+The agent reads from a local copy of the issue and its comments, so nothing hits GitHub live. It'll plan its own approach, call its tools, and write up what it finds in a file.
+
+It works. But it's all happening in memory. If anything crashes, it's gone. That's what we fix next.
+
+The sandbox for this challenge is being prepared, it should be ready within a few seconds. Once it's ready, click the 'Start' button.
+
+### What you'll learn in this challenge
+
+- How to run a DeepAgent from the command line
+- What it looks like when an agent plans and calls tools on its own
+- Where the finished investigation report ends up
+- Why running it all in memory is a problem

--- a/ai-agents-deepagents/build-the-agent/tabs.md
+++ b/ai-agents-deepagents/build-the-agent/tabs.md
@@ -1,0 +1,13 @@
+# Tab configuration
+
+## Editor
+
+type: code editor
+host: {{...}}
+path: ai-agent-tracks-instruqt/deepagents/deep-investigation
+
+## Terminal
+
+type: terminal
+host: {{...}}
+path: ai-agent-tracks-instruqt/deepagents/deep-investigation

--- a/ai-agents-deepagents/crash-the-agent/assignment.md
+++ b/ai-agents-deepagents/crash-the-agent/assignment.md
@@ -1,0 +1,83 @@
+This is the payoff. You're going to crash the investigation on purpose, then prove the workflow picks up exactly where it left off.
+
+## 1. Find the crash line
+
+Open `tools_crash.py` in the **Editor**. This is the same `get_comments` tool as before, with one line added — **line 34**:
+
+```python,nocopy
+os._exit(1)  # Simulates a crash — comment out this line before the second run
+```
+
+`investigate.py` (the active copy of `investigate-crash.py`) imports tools from `tools_crash.py`. `os._exit(1)` kills the Python process immediately — no exception, no cleanup, no chance for Dapr to gracefully shut down. This simulates a hard infrastructure failure: a pod eviction, an OOM kill, a host reboot.
+
+The script also uses a `crash_state.json` file to persist the Dapr workflow ID across restarts. On the first run it writes this file when the `workflow_started` event fires; on the second run it detects the file and polls the **existing** workflow rather than starting a new one.
+
+## 2. Trigger the crash
+
+Use the **Terminal** window to start the investigation:
+
+```bash,run
+uv run dapr run --app-id deepagent --resources-path ./resources -- python investigate.py --issue 1833
+```
+
+Watch the terminal. The agent calls `get_issue` first — that activity completes and gets checkpointed. The workflow ID is saved to `crash_state.json`. Then the agent calls `get_comments`, and the process dies. The terminal output stops; there is no graceful shutdown message.
+
+Verify the crash was recorded:
+
+```bash,run
+cat crash_state.json
+```
+
+```text,nocopy
+{
+  "workflow_scheduled": true,
+  "workflow_id": "graph-investigation-1833-<uuid>",
+  "run_count": 1
+}
+```
+
+> [!NOTE]
+> The `workflow_id` is the handle to the in-flight Dapr workflow. The script uses it on the next run to reconnect to the same instance rather than starting a new one.
+
+## 3. Remove the crash
+
+Back in the **Editor**, comment out line 34 in `tools_crash.py`:
+
+```python,nocopy
+# os._exit(1)  # Simulates a crash — comment out this line before the second run
+```
+
+## 4. Run again — watch the recovery
+
+Use the **Terminal** window to restart the investigation:
+
+```bash,run
+uv run dapr run --app-id deepagent --resources-path ./resources -- python investigate.py --issue 1833
+```
+
+Watch closely: the script detects `crash_state.json`, skips `run_async()`, and polls the **same** workflow instance by its saved ID. The Dapr Workflow engine replays history up to the last checkpoint and continues execution from `get_comments` — `get_issue` is **not** called again. Execution continues from where it crashed, and the investigation completes.
+
+> [!IMPORTANT]
+> The key proof is in the logs: you will not see `get_issue` being executed again. Dapr's replay mechanism skips any activity whose result is already in the checkpoint store.
+
+## 5. Read the report
+
+```bash,run
+cat investigation-1833.md
+```
+
+A complete report, even though the process that produced it died and restarted halfway through.
+
+## 6. How this works
+
+1. On the first run, `run_async()` starts a new Dapr Workflow and saves the workflow ID to `crash_state.json` when `workflow_started` fires.
+2. `os._exit(1)` kills the process hard — the activity result for `get_comments` is not written, but `get_issue`'s result is already in Redis.
+3. On the second run, the script detects `crash_state.json` and skips `run_async()`. Instead it calls `poll_for_completion()` using the saved workflow ID.
+4. Dapr reconnects to the existing workflow instance, replays checkpointed activities (returning their saved results without re-executing them), and resumes at `get_comments`.
+5. The investigation completes and `investigation-1833.md` is written to disk.
+
+That's the entire point of backing a long-running agent with Dapr: a crash costs you a restart, not the work.
+
+---
+
+You've completed the track. From here you could add sub-agents for parallel investigation, point the same pattern at a different issue, or wire in Dapr's Conversation API for additional LLM-call resiliency.

--- a/ai-agents-deepagents/crash-the-agent/tabs.md
+++ b/ai-agents-deepagents/crash-the-agent/tabs.md
@@ -1,0 +1,13 @@
+# Tab configuration
+
+## Editor
+
+type: code editor
+host: {{...}}
+path: ai-agent-tracks-instruqt/deepagents/deep-investigation
+
+## Terminal
+
+type: terminal
+host: {{...}}
+path: ai-agent-tracks-instruqt/deepagents/deep-investigation

--- a/ai-agents-deepagents/introduction/assignment.md
+++ b/ai-agents-deepagents/introduction/assignment.md
@@ -1,0 +1,78 @@
+Welcome to **Deep Issue Investigation that Survives the Long Haul**. In this track you'll build a CLI tool that points a [DeepAgents](https://docs.langchain.com/oss/python/deepagents) agent at a real, gnarly GitHub issue and has it write an investigation report — then make that investigation durable enough to survive a crash.
+
+## What is DeepAgents?
+
+DeepAgents is a framework, built on [LangGraph](https://www.langchain.com/langgraph), that gives an LLM three things a plain chat loop doesn't have:
+
+- **Planning** — the agent breaks a vague instruction ("investigate this issue") into its own steps before acting.
+- **Tools** — functions the agent can call to read data (in our case, a local GitHub snapshot — never the live API).
+- **A virtual filesystem** — a scratchpad the agent reads and writes to as it works, including the final report.
+
+## Why durability matters
+
+A real investigation isn't one LLM call — it's dozens of tool calls and reasoning steps, and it can take minutes. All of that lives in memory by default. Kill the process at step 30 of 40 and you lose everything: the scratchpad, the partial report, and every dollar spent on LLM calls so far.
+
+In challenges 3 and 4 you'll back that scratchpad with a **Dapr state store** and wrap the run in a **Dapr Workflow**, so a crashed investigation resumes exactly where it left off instead of starting over.
+
+## The target issue
+
+We've picked one issue for this whole track: [dapr/dapr#1833](https://github.com/dapr/dapr/issues/1833) — "Data corruption in actor/service invocation under high rps." It's closed, has real comment threads, and was fixed by a real pull request. You won't choose an issue yourself — every challenge investigates #1833.
+
+## 1. Verify the sandbox
+
+Use the **Terminal** window to confirm the Dapr CLI and runtime are ready:
+
+```bash,run
+dapr -v
+```
+
+> [!NOTE]
+> You should see both a **CLI version** and a **Runtime version**. If Runtime version is empty, the sandbox didn't initialize correctly — flag it.
+
+```bash,run
+ls track-data-real/dapr/dapr
+```
+This is a static snapshot of issues and pull requests from the real dapr/dapr repository, collected once and checked into this track. The agent only ever reads from this local snapshot.
+
+```bash,run
+cat track-data-real/dapr/dapr/manifest.json
+```
+```text,nocopy
+{
+  "schema_version": 1,
+  "owner": "dapr",
+  "repo": "dapr",
+  ...
+  "seed_issues": [
+    1833
+  ],
+  "counts": {
+    "issues": 100,
+    "prs": 50
+  }
+}
+```
+`seed_issues` confirms #1833 is in the snapshot. `counts` tells you how much data was collected around it.
+
+## 2. Add your OpenAI API key
+
+Create a `.env` file in the project directory:
+
+```bash,run,copy
+touch .env
+```
+> [!IMPORTANT]
+> Refresh the 'Editor' tab, so it detects the newly created file. You'll find the arrow on the right side of the tree view labelled DEEP-INVESTIGATION.
+
+Open it in the **Editor** and add your key:
+
+```env,nocopy
+OPENAI_API_KEY=your_key_here
+```
+
+> [!NOTE]
+> You'll need a real key from https://platform.openai.com/signup as the agent calls `gpt-4o-mini` in every challenge from here on.
+
+---
+
+You now have a working sandbox and a local GitHub snapshot ready for investigation. Let's move on to challenge 2 where you'll run the agent for the first time.

--- a/ai-agents-deepagents/introduction/notes.md
+++ b/ai-agents-deepagents/introduction/notes.md
@@ -1,0 +1,12 @@
+DeepAgents lets you build an AI agent that can plan, use tools, and take notes as it works. It's how you get real, multi-step investigations out of an LLM instead of a single guess. The challenge will take about 5 minutes.
+
+There's a catch though. If a long-running agent crashes halfway, you lose all its progress and pay for every model call again. The rest of this track shows how Dapr fixes that.
+
+The sandbox for this challenge is being prepared, it should be ready within a few seconds. Once it's ready, click the 'Start' button.
+
+### What you'll learn in this challenge
+
+- What DeepAgents actually is, and why long-running agents are useful
+- Why crashes are such a painful problem for these agents
+- How to confirm your sandbox is ready to go
+- Where the pre-loaded issue data lives

--- a/ai-agents-deepagents/introduction/scripts/setup.sh
+++ b/ai-agents-deepagents/introduction/scripts/setup.sh
@@ -1,0 +1,7 @@
+git clone https://github.com/diagrid-labs/ai-agent-tracks-instruqt.git
+
+cd ai-agent-tracks-instruqt/deepagents/deep-investigation
+
+cat > .env << 'EOF'
+OPENAI_API_KEY=your_key_here
+EOF

--- a/ai-agents-deepagents/introduction/tabs.md
+++ b/ai-agents-deepagents/introduction/tabs.md
@@ -1,0 +1,13 @@
+# Tab configuration
+
+## Editor
+
+type: code editor
+host: {{...}}
+path: ai-agent-tracks-instruqt/deepagents/deep-investigation
+
+## Terminal
+
+type: terminal
+host: {{...}}
+path: ai-agent-tracks-instruqt/deepagents/deep-investigation

--- a/ai-agents-deepagents/make-it-durable/assignment.md
+++ b/ai-agents-deepagents/make-it-durable/assignment.md
@@ -1,0 +1,72 @@
+The baseline agent worked, but everything it did lived in process memory. In this challenge you'll wrap the exact same agent in a **Dapr Workflow**, so its scratchpad and progress are persisted as it runs.
+
+## 1. Inspect the durable version
+
+Open `investigate.py` in the **Editor**. The agent definition is unchanged — same tools, same system prompt. What's new is the entry point:
+
+```python,nocopy
+from diagrid.agent.deepagents import DaprWorkflowDeepAgentRunner
+
+runner = DaprWorkflowDeepAgentRunner(
+    agent=agent,
+    name="issue-investigation",
+    max_steps=50,
+)
+```
+
+Instead of `agent.invoke(...)`, the script now calls `runner.start()` and streams events from `runner.run_async(...)`. Under the hood, every tool call the agent makes becomes a **Dapr Workflow activity** — and Dapr checkpoints each activity's result before moving to the next one.
+
+## 2. Inspect the state store
+
+Open `resources/statestore.yaml` in the **Editor**:
+
+```yaml,nocopy
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: agent-memory
+spec:
+  type: state.redis
+  version: v1
+  metadata:
+    - name: redisHost
+      value: localhost:6379
+    - name: redisPassword
+      value: ""
+    - name: actorStateStore
+      value: "true"
+```
+
+This is a Redis-backed Dapr state store named `agent-memory` — the name the DeepAgents Dapr integration looks for by convention. `actorStateStore: "true"` means it also backs the Dapr Workflow engine itself (workflows run on Dapr's actor runtime under the hood).
+
+## 3. Run the durable investigation
+
+Use the **Terminal** window to run the agent with Dapr:
+
+```bash,run
+uv run dapr run --app-id deepagent --resources-path ./resources -- python investigate.py --issue 1833
+```
+
+Watch the terminal — you'll see the same tool calls as challenge 2, but now interleaved with `Event: workflow_started`, `Event: workflow_status_changed`, and `Event: workflow_completed` as Dapr tracks the run.
+
+## 4. Read the report
+
+```bash,run
+cat investigation-1833.md
+```
+
+Same report quality as challenge 2 — but this time, if the process had died halfway through, the work up to that point wouldn't be lost. That's exactly what you'll prove next.
+
+## 5. How this works
+
+1. `DaprWorkflowDeepAgentRunner.start()` registers the agent graph as a Dapr Workflow and starts the actor runtime.
+2. Each node in the LangGraph state machine (tool call, model call, middleware) is wrapped as a Dapr Workflow activity.
+3. Before Dapr moves to the next activity, it writes the result of the current one to the Redis state store.
+4. If the process dies, the workflow engine can replay history up to the last checkpoint and resume from there on restart.
+
+> [!IMPORTANT]
+> Use `Ctrl+C` in the **Terminal** window to stop the Dapr application before moving on.
+
+---
+
+You've now run the same investigation backed by a Dapr Workflow, with every step checkpointed to Redis. Let's move on to challenge 4 where you'll prove this works by intentionally crashing the process mid-investigation.

--- a/ai-agents-deepagents/make-it-durable/notes.md
+++ b/ai-agents-deepagents/make-it-durable/notes.md
@@ -1,0 +1,14 @@
+Same investigation, but now Dapr is saving the agent's work as it goes. The challenge will take about 5 minutes.
+
+Instead of the agent keeping its notes in memory, every step gets saved to a Redis state store. After the run, you can peek into the actual saved state through the terminal — proof it's not just floating in the process anymore.
+
+This is the setup for the crash recovery in the next challenge.
+
+The sandbox for this challenge is being prepared, it should be ready within a few seconds. Once it's ready, click the 'Start' button.
+
+### What you'll learn in this challenge
+
+- How to swap in-memory state for durable state with Dapr
+- What a Dapr state store component looks like
+- How to check the saved state directly in Redis
+- Why this small change makes crash recovery possible

--- a/ai-agents-deepagents/make-it-durable/tabs.md
+++ b/ai-agents-deepagents/make-it-durable/tabs.md
@@ -1,0 +1,13 @@
+# Tab configuration
+
+## Editor
+
+type: code editor
+host: {{...}}
+path: ai-agent-tracks-instruqt/deepagents/deep-investigation
+
+## Terminal
+
+type: terminal
+host: {{...}}
+path: ai-agent-tracks-instruqt/deepagents/deep-investigation


### PR DESCRIPTION
Adds four challenges teaching DeepAgents:

Introduction to the sandbox and issue data, running a baseline agent, making it durable with Dapr state store, and proving crash recovery by intentionally killing and restarting the investigation mid-process.

Note: In the `tabs.md`, the host is currently placed as a placeholder. When it starts working we will replace it with the actual host.