### PR TITLE
Add Robot Framework drift tests for dapr-workflow-aspire

### DIFF
--- a/.github/workflows/test-dapr-workflow-aspire.yml
+++ b/.github/workflows/test-dapr-workflow-aspire.yml
@@ -73,7 +73,12 @@ jobs:
               `The dapr-workflow-aspire drift test **failed**.`,
               ``,
               `- Run: ${runUrl}`,
-              `- Download the \`robot-aspire\` artifact and open \`report.html\` / \`log.html\` for the failing checkpoint.`,
+              `- Download the \`robot-aspire\` artifact and open \`report.html\` (every checkpoint listed; failures in red) or \`log.html\`.`,
+              ``,
+              `Download and open the report:`,
+              '```bash',
+              `gh run download ${context.runId} -n robot-aspire -D ./report-aspire`,
+              '```',
               ``,
               `_This issue is updated automatically each run._`,
             ].join('\n');

--- a/.github/workflows/test-dapr-workflow-aspire.yml
+++ b/.github/workflows/test-dapr-workflow-aspire.yml
@@ -15,6 +15,16 @@ permissions:
   issues: write
 
 jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Sync harness
+        run: (cd tools/track-tester && uv sync)
+      - name: Run harness unit tests
+        run: (cd tools/track-tester && uv run pytest -v)
+
   build-and-run:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-dapr-workflow-aspire.yml
+++ b/.github/workflows/test-dapr-workflow-aspire.yml
@@ -1,0 +1,85 @@
+name: Test dapr-workflow-aspire track
+
+on:
+  schedule:
+    - cron: '30 6 * * 2'   # Tuesdays 06:30 UTC (offset from dapr-workflow's Monday run)
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'dapr-workflow-aspire/**'
+      - 'tools/track-tester/**'
+      - '.github/workflows/test-dapr-workflow-aspire.yml'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  build-and-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Set up .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+      - name: Install Aspire CLI
+        run: |
+          curl -sSL https://aspire.dev/install.sh | bash
+          # The installer prints the install dir; add the common location to PATH.
+          echo "$HOME/.aspire/bin" >> "$GITHUB_PATH"
+      - name: Install Aspire project templates
+        # Provides `dotnet new aspire-starter`. If drift makes the scaffold fail,
+        # pin the version here to match the sandbox image (see spec deferred item).
+        run: dotnet new install Aspire.ProjectTemplates
+      - name: Setup Dapr sandbox
+        run: bash tools/track-tester/ci/setup-dapr-workflow-aspire.sh
+      - name: Sync harness
+        run: (cd tools/track-tester && uv sync)
+      - name: Run aspire track suite
+        run: |
+          cd tools/track-tester
+          mkdir -p results
+          uv run robot --outputdir results --name "dapr-workflow-aspire" \
+            ../../dapr-workflow-aspire/tests/challenge.robot
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: robot-aspire
+          path: tools/track-tester/results/
+
+  report:
+    needs: [build-and-run]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'Dapr Workflow Aspire track drift detected';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `The dapr-workflow-aspire drift test **failed**.`,
+              ``,
+              `- Run: ${runUrl}`,
+              `- Download the \`robot-aspire\` artifact and open \`report.html\` / \`log.html\` for the failing checkpoint.`,
+              ``,
+              `_This issue is updated automatically each run._`,
+            ].join('\n');
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: 'drift-report',
+            });
+            const match = existing.data.find(i => i.title === title);
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: match.number, body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels: ['drift-report'],
+              });
+            }

--- a/.github/workflows/test-dapr-workflow-aspire.yml
+++ b/.github/workflows/test-dapr-workflow-aspire.yml
@@ -39,10 +39,10 @@ jobs:
           curl -sSL https://aspire.dev/install.sh | bash
           # The installer prints the install dir; add the common location to PATH.
           echo "$HOME/.aspire/bin" >> "$GITHUB_PATH"
-      - name: Install Aspire project templates
-        # Provides `dotnet new aspire-starter`. If drift makes the scaffold fail,
-        # pin the version here to match the sandbox image (see spec deferred item).
-        run: dotnet new install Aspire.ProjectTemplates
+      # The Aspire project templates are NOT installed here: the suite's first
+      # checkpoint (Ch1) runs the pinned `dotnet new install Aspire.ProjectTemplates@<ver>`
+      # command extracted from 1-introduction/assignment.md, so the pinned version
+      # stays a single source of truth in the assignment (and drift in it is caught).
       - name: Setup Dapr sandbox
         run: bash tools/track-tester/ci/setup-dapr-workflow-aspire.sh
       - name: Sync harness

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+**/settings.local.json
+
 .idea/
 **/.DS_Store
 

--- a/dapr-workflow-aspire/2-project-creation/assignment.md
+++ b/dapr-workflow-aspire/2-project-creation/assignment.md
@@ -42,8 +42,8 @@ Replace the entire contents of the file with this json:
         "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://0.0.0.0:17001",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://0.0.0.0:17003",
-        "DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS": true,
-        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": true
+        "DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     }
   }

--- a/dapr-workflow-aspire/2-project-creation/assignment.md
+++ b/dapr-workflow-aspire/2-project-creation/assignment.md
@@ -55,13 +55,12 @@ Replace the entire contents of the file with this json:
 
 ## 3. Add the NuGet packages
 
-Now let's install some dependencies the solution requires. You're building a Dapr Workflow solution and this needs: `Dapr.Workflow`, `Dapr.Workflow.Versioning` and `CommunityToolkit.Aspire.Hosting.Dapr`.
+Now let's install some dependencies the solution requires. You're building a Dapr Workflow solution and this needs: `Dapr.Workflow` and `CommunityToolkit.Aspire.Hosting.Dapr`. As of version 1.18, the workflow-versioning APIs are included in the `Dapr.Workflow` package itself, so there's no separate package to add for that.
 
 1. Use the *Terminal* (ensure you're in `EnterpriseDiagnostics/`) to install all the required packages to the correct projects:
 
 ```shell,run,copy
 dotnet add EnterpriseDiagnostics.ApiService/EnterpriseDiagnostics.ApiService.csproj package Dapr.Workflow --version 1.18.4
-dotnet add EnterpriseDiagnostics.ApiService/EnterpriseDiagnostics.ApiService.csproj package Dapr.Workflow.Versioning --version 1.18.4
 dotnet add EnterpriseDiagnostics.AppHost/EnterpriseDiagnostics.AppHost.csproj package CommunityToolkit.Aspire.Hosting.Dapr --version 13.0.0
 ```
 
@@ -75,7 +74,6 @@ The ApiService project  should have these packages:
 
 ```text,nocopy
 <PackageReference Include="Dapr.Workflow" Version="1.18.4" />
-<PackageReference Include="Dapr.Workflow.Versioning" Version="1.18.4" />
 <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
 ```
 

--- a/dapr-workflow-aspire/tests/challenge.robot
+++ b/dapr-workflow-aspire/tests/challenge.robot
@@ -1,0 +1,56 @@
+*** Settings ***
+Name              Dapr Workflow Aspire
+Documentation     Drift test for dapr-workflow-aspire: reconstruct the build-it-live
+...               app from the assignments, build it, run it, assert the workflow completes.
+Library           ../../tools/track-tester/libraries/assignment_blocks.py
+Resource          ../../tools/track-tester/resources/workflow.resource
+Variables         ../../tools/track-tester/variables/dapr_workflow_aspire.py
+Suite Setup       Prepare Workdir
+Suite Teardown    Terminate All Processes    kill=True
+
+*** Variables ***
+${WORKDIR}        ${TEMPDIR}${/}eds-track
+${SOLUTION_DIR}   ${WORKDIR}${/}EnterpriseDiagnostics
+${LOG}            ${TEMPDIR}/dapr-workflow-aspire.log
+${ASSIGN_2}       ${CURDIR}/../2-project-creation/assignment.md
+${ASSIGN_3}       ${CURDIR}/../3-workflow-definition/assignment.md
+${ASSIGN_4}       ${CURDIR}/../4-apphost-resources/assignment.md
+${ASSIGN_5}       ${CURDIR}/../5-run-application/assignment.md
+
+*** Keywords ***
+Prepare Workdir
+    # Start from a clean working directory so reruns don't collide with a stale scaffold.
+    Remove Directory    ${WORKDIR}    recursive=True
+    Create Directory    ${WORKDIR}
+
+*** Test Cases ***
+Ch2 Scaffold And Build
+    # Scaffold runs in ${WORKDIR}; the assignment's `cd EnterpriseDiagnostics`
+    # moves into the solution. Writes launchSettings.json, adds the pinned NuGet
+    # packages, and builds. `aspire run` is skipped (launched only in Ch5).
+    Apply Challenge    ${ASSIGN_2}    ${WORKDIR}    ${SOLUTION_DIR}    ${MANIFEST_CH2}
+    File Should Contain
+    ...    ${SOLUTION_DIR}/EnterpriseDiagnostics.ApiService/EnterpriseDiagnostics.ApiService.csproj
+    ...    Dapr.Workflow
+
+Ch3 Workflow Build
+    # Creates the Models/Workflows/Activities folders + files and rebuilds.
+    Apply Challenge    ${ASSIGN_3}    ${SOLUTION_DIR}    ${SOLUTION_DIR}    ${MANIFEST_CH3}
+
+Ch4 AppHost Build
+    # Writes the two Dapr component files, splices the <Content> item group into the
+    # AppHost csproj, replaces AppHost.cs, and rebuilds.
+    Apply Challenge    ${ASSIGN_4}    ${SOLUTION_DIR}    ${SOLUTION_DIR}    ${MANIFEST_CH4}
+
+Ch5 Run And Assert
+    [Teardown]    Stop Process With SIGINT    app
+    # Launch `aspire run` (from the assignment) in the background; it starts the
+    # ApiService + its Dapr sidecar. Skip the diagrid-dashboard docker step.
+    ${aspire}=    Get Command Containing    ${ASSIGN_5}    aspire run
+    Start Background Process    ${aspire}    ${LOG}    app    cwd=${SOLUTION_DIR}
+    Wait Until App Responds    ${APISERVICE_URL}    timeout=240s
+    # Start the workflow with the assignment's exact curl, then poll until the
+    # output echoes the input stardate (present only once the workflow completes).
+    ${start}=    Get Command Containing    ${ASSIGN_5}    /start
+    Run And Expect RC Zero    ${start}
+    Wait Until Command Output Contains    curl -s ${STATUS_URL}    ${EXPECTED_STARDATE}    timeout=120s

--- a/dapr-workflow-aspire/tests/challenge.robot
+++ b/dapr-workflow-aspire/tests/challenge.robot
@@ -11,7 +11,7 @@ Suite Teardown    Terminate All Processes    kill=True
 *** Variables ***
 ${WORKDIR}        ${TEMPDIR}${/}eds-track
 ${SOLUTION_DIR}   ${WORKDIR}${/}EnterpriseDiagnostics
-${LOG}            ${TEMPDIR}/dapr-workflow-aspire.log
+${LOG}            ${OUTPUT DIR}/aspire-run.log
 ${ASSIGN_1}       ${CURDIR}/../1-introduction/assignment.md
 ${ASSIGN_2}       ${CURDIR}/../2-project-creation/assignment.md
 ${ASSIGN_3}       ${CURDIR}/../3-workflow-definition/assignment.md

--- a/dapr-workflow-aspire/tests/challenge.robot
+++ b/dapr-workflow-aspire/tests/challenge.robot
@@ -12,6 +12,7 @@ Suite Teardown    Terminate All Processes    kill=True
 ${WORKDIR}        ${TEMPDIR}${/}eds-track
 ${SOLUTION_DIR}   ${WORKDIR}${/}EnterpriseDiagnostics
 ${LOG}            ${TEMPDIR}/dapr-workflow-aspire.log
+${ASSIGN_1}       ${CURDIR}/../1-introduction/assignment.md
 ${ASSIGN_2}       ${CURDIR}/../2-project-creation/assignment.md
 ${ASSIGN_3}       ${CURDIR}/../3-workflow-definition/assignment.md
 ${ASSIGN_4}       ${CURDIR}/../4-apphost-resources/assignment.md
@@ -24,6 +25,16 @@ Prepare Workdir
     Create Directory    ${WORKDIR}
 
 *** Test Cases ***
+Ch1 Install Aspire Templates
+    # ch1 sets up the environment. The one drift-sensitive, environment-agnostic
+    # step is pinning the Aspire project templates to a sandbox-compatible version
+    # (the assignment warns NOT to use 13.4.*, which rejects the 0.0.0.0 binding
+    # used later). Extract and run that pin from the assignment so it auto-follows
+    # if the pinned version changes. The Aspire CLI install (`curl | bash`) and the
+    # `source /root/.bashrc` shell reload are sandbox/CI provisioning, not run here.
+    ${pin}=    Get Command Containing    ${ASSIGN_1}    Aspire.ProjectTemplates
+    Run And Expect RC Zero    ${pin}
+
 Ch2 Scaffold And Build
     # Scaffold runs in ${WORKDIR}; the assignment's `cd EnterpriseDiagnostics`
     # moves into the solution. Writes launchSettings.json, adds the pinned NuGet

--- a/docs/superpowers/plans/2026-07-23-dapr-workflow-aspire-drift-tests.md
+++ b/docs/superpowers/plans/2026-07-23-dapr-workflow-aspire-drift-tests.md
@@ -1,0 +1,884 @@
+# dapr-workflow-aspire Drift Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Robot Framework drift tests for the `dapr-workflow-aspire` track that reconstruct the build-it-live app by extracting the exact `,copy`/`,run` blocks from the assignments, build it, run it, and assert the workflow completes.
+
+**Architecture:** A Python extraction library parses each `assignment.md` into fenced blocks, runs its `shell,run` commands (tracking `cd`), and writes its `,copy` file blocks to destinations mapped by a per-challenge manifest — raising on any unmapped writable block (fail-loud coverage). A single cumulative Robot suite drives four ordered checkpoints (ch2 scaffold+build → ch3 workflow build → ch4 apphost build → ch5 run+assert) in one working directory. A new CI workflow provisions .NET 10 + Aspire + Dapr and runs the suite.
+
+**Tech Stack:** Robot Framework 7 (existing harness under `tools/track-tester/`), Python 3.12, pytest, .NET 10, Aspire CLI, Dapr CLI, Docker.
+
+## Global Constraints
+
+- **Harness location & run dir:** all `uv`/`robot`/`pytest` commands run from `tools/track-tester/`. Suite paths are written relative to that dir (`../../dapr-workflow-aspire/...`).
+- **Track is build-it-live:** the app code lives ONLY in the assignments' `,copy` blocks. Never commit a copy of the app; always extract from `assignment.md`.
+- **Fence tags:** this track uses `shell,run` / `shell,run,copy` (NOT `bash,run`) for commands, and `csharp,copy` / `json,copy` / `yaml,copy` / `xml,copy` (sometimes with `,wrap`) for file content. `,nocopy` blocks are display-only — never run or write them.
+- **Cumulative challenges:** ch3 needs ch2's scaffold, ch4 needs ch3, ch5 runs the lot. One working directory, ordered test cases.
+- **Single language:** .NET only. No dotnet/java/python tag matrix.
+- **Pinned versions (drift-sensitive, do not "upgrade"):** `Dapr.Workflow 1.18.4`, `Dapr.Workflow.Versioning 1.18.4`, `CommunityToolkit.Aspire.Hosting.Dapr 13.0.0`; `dotnet new aspire-starter`.
+- **Fixed runtime endpoints:** ApiService at `http://localhost:5411`; workflow started with `{"id":"mission-001","starDate":"41153.7"}`; status at `http://localhost:5411/status/mission-001`.
+- **Do not run the diagrid-dashboard** (`docker run … diagrid-dashboard`) or ch2's `aspire run` verification step in the batch apply — the dashboard is read-only visualization and `aspire run` is launched explicitly (background) only in the ch5 checkpoint.
+- **No changes** to `check_doc_sync.py`, the dapr-101/dapr-workflow suites, or the `dapr-workflow-aspire` assignment content.
+- **Commit message trailer:** end each commit message with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+---
+
+## File Structure
+
+**New files:**
+- `tools/track-tester/libraries/assignment_blocks.py` — fence parser, block classification, file-mapping resolver (fail-loud), and the `AssignmentBlocks` Robot library (impure apply/get keywords).
+- `tools/track-tester/libraries/tests/test_parse.py` — pytest for the pure parser/resolver functions.
+- `tools/track-tester/libraries/tests/test_apply.py` — pytest for the impure apply logic against a synthetic assignment (no .NET needed).
+- `tools/track-tester/libraries/tests/test_manifest.py` — pytest validating the real manifests against the real assignment files.
+- `tools/track-tester/variables/dapr_workflow_aspire.py` — URLs, expected values, and the per-challenge block→file manifests.
+- `dapr-workflow-aspire/tests/challenge.robot` — the cumulative suite.
+- `tools/track-tester/ci/setup-dapr-workflow-aspire.sh` — CI sandbox reproduction (uv, Dapr, `dapr init`).
+- `.github/workflows/test-dapr-workflow-aspire.yml` — CI workflow.
+
+**Modified files:**
+- `tools/track-tester/pyproject.toml` — add `libraries` and `variables` to pytest `pythonpath`/`testpaths`.
+
+---
+
+## Task 1: Pure extraction functions (parser + resolver)
+
+**Files:**
+- Create: `tools/track-tester/libraries/assignment_blocks.py`
+- Create: `tools/track-tester/libraries/tests/test_parse.py`
+- Modify: `tools/track-tester/pyproject.toml`
+
+**Interfaces:**
+- Produces:
+  - `Block` dataclass: `lang: str`, `tags: tuple[str, ...]`, `body: str`.
+  - `parse_blocks(md_text: str) -> list[Block]`
+  - `is_run_block(b: Block) -> bool` (`lang == "shell" and "run" in tags`)
+  - `is_writable_block(b: Block) -> bool` (`lang in {"csharp","json","yaml","xml"} and "copy" in tags`)
+  - `command_lines(body: str) -> list[str]` (join `\`-continuations, drop blank/`#` lines)
+  - `class UnmappedBlockError(Exception)`
+  - `dest_for_block(b: Block, manifest: list[tuple[str,str,str]]) -> tuple[str,str]` → `(dest, mode)`; raises `UnmappedBlockError` on 0 or >1 anchor matches.
+  - `resolve_files(blocks, manifest) -> list[tuple[str,str,str]]` → `[(dest, mode, body)]`; raises if any writable block is unmapped/ambiguous or any manifest anchor matches no block.
+
+- [ ] **Step 1: Add pytest paths to pyproject.toml**
+
+Modify `tools/track-tester/pyproject.toml`, replacing the `[tool.pytest.ini_options]` block:
+
+```toml
+[tool.pytest.ini_options]
+pythonpath = ["docsync", "libraries", "variables"]
+testpaths = ["docsync/tests", "libraries/tests"]
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `tools/track-tester/libraries/tests/test_parse.py`:
+
+```python
+import pytest
+from assignment_blocks import (
+    Block,
+    parse_blocks,
+    is_run_block,
+    is_writable_block,
+    command_lines,
+    dest_for_block,
+    resolve_files,
+    UnmappedBlockError,
+)
+
+MD = """
+Intro.
+
+```shell,run
+dotnet new aspire-starter -n EnterpriseDiagnostics -o EnterpriseDiagnostics
+```
+
+```shell,run,copy
+cd EnterpriseDiagnostics
+```
+
+```json,copy
+{ "$schema": "https://json.schemastore.org/launchsettings.json" }
+```
+
+```text,nocopy
+display only, ignored
+```
+"""
+
+
+def test_parse_captures_lang_tags_body():
+    blocks = parse_blocks(MD)
+    assert [(b.lang, b.tags) for b in blocks] == [
+        ("shell", ("run",)),
+        ("shell", ("run", "copy")),
+        ("json", ("copy",)),
+        ("text", ("nocopy",)),
+    ]
+    assert blocks[0].body == "dotnet new aspire-starter -n EnterpriseDiagnostics -o EnterpriseDiagnostics"
+
+
+def test_classification():
+    blocks = parse_blocks(MD)
+    assert [is_run_block(b) for b in blocks] == [True, True, False, False]
+    assert [is_writable_block(b) for b in blocks] == [False, False, True, False]
+
+
+def test_command_lines_joins_continuations_and_drops_comments():
+    body = "# a comment\ndocker run -p 1:1 \\\n  -e X=y \\\n  image\n\ntouch f"
+    assert command_lines(body) == ["docker run -p 1:1 -e X=y image", "touch f"]
+
+
+def test_resolve_files_maps_by_anchor():
+    blocks = parse_blocks(MD)
+    manifest = [('"$schema": "https://json.schemastore.org/launchsettings.json"',
+                 "AppHost/Properties/launchSettings.json", "write")]
+    resolved = resolve_files(blocks, manifest)
+    assert len(resolved) == 1
+    dest, mode, body = resolved[0]
+    assert dest == "AppHost/Properties/launchSettings.json"
+    assert mode == "write"
+    assert "$schema" in body
+
+
+def test_resolve_files_raises_on_unmapped_block():
+    blocks = parse_blocks("```csharp,copy\nclass Orphan {}\n```")
+    with pytest.raises(UnmappedBlockError):
+        resolve_files(blocks, [])
+
+
+def test_resolve_files_raises_when_anchor_matches_nothing():
+    blocks = parse_blocks(MD)
+    manifest = [
+        ('"$schema": "https://json.schemastore.org/launchsettings.json"',
+         "AppHost/Properties/launchSettings.json", "write"),
+        ("anchor that is absent", "nowhere.cs", "write"),
+    ]
+    with pytest.raises(UnmappedBlockError):
+        resolve_files(blocks, manifest)
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `(cd tools/track-tester && uv run pytest libraries/tests/test_parse.py -v)`
+Expected: FAIL — `ModuleNotFoundError: No module named 'assignment_blocks'`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `tools/track-tester/libraries/assignment_blocks.py`:
+
+```python
+"""Extract and apply a dapr-workflow-aspire assignment's build-it-live steps.
+
+The track has no upstream repo: every file the learner creates is pasted from a
+``,copy`` fenced block and every command is a ``shell,run`` block. This module
+parses those blocks so the Robot suite can reconstruct the app exactly as the
+assignment describes, catching drift in the tooling the assignment depends on.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+
+_FENCE_RE = re.compile(r"^```([^\n`]*)$")
+_WRITABLE_LANGS = {"csharp", "json", "yaml", "xml"}
+
+
+@dataclass(frozen=True)
+class Block:
+    lang: str              # first token of the info string, e.g. "shell", "csharp"
+    tags: tuple[str, ...]  # remaining comma flags, e.g. ("run",), ("copy",)
+    body: str              # block contents, fences stripped
+
+
+def parse_blocks(md_text: str) -> list[Block]:
+    blocks: list[Block] = []
+    in_fence = False
+    info = ""
+    lines: list[str] = []
+    for line in md_text.splitlines():
+        fence = _FENCE_RE.match(line.strip())
+        if fence is not None:
+            if not in_fence:
+                in_fence, info, lines = True, fence.group(1), []
+            else:
+                parts = [p.strip() for p in info.split(",") if p.strip()]
+                lang = parts[0] if parts else ""
+                blocks.append(Block(lang=lang, tags=tuple(parts[1:]), body="\n".join(lines)))
+                in_fence = False
+        elif in_fence:
+            lines.append(line)
+    return blocks
+
+
+def is_run_block(b: Block) -> bool:
+    return b.lang == "shell" and "run" in b.tags
+
+
+def is_writable_block(b: Block) -> bool:
+    return b.lang in _WRITABLE_LANGS and "copy" in b.tags
+
+
+def command_lines(body: str) -> list[str]:
+    """Logical command lines: join trailing-backslash continuations, drop blank
+    and comment lines."""
+    out: list[str] = []
+    buf = ""
+    for raw in body.splitlines():
+        line = raw.rstrip()
+        if not line.strip() or line.strip().startswith("#"):
+            continue
+        if line.endswith("\\"):
+            buf += line[:-1] + " "
+        else:
+            out.append((buf + line).strip())
+            buf = ""
+    if buf.strip():
+        out.append(buf.strip())
+    return out
+
+
+class UnmappedBlockError(Exception):
+    """A writable block has no (or an ambiguous) manifest mapping."""
+
+
+def dest_for_block(b: Block, manifest: list[tuple[str, str, str]]) -> tuple[str, str]:
+    matches = [(anchor, dest, mode) for anchor, dest, mode in manifest if anchor in b.body]
+    first_line = b.body.splitlines()[0] if b.body else "<empty>"
+    if not matches:
+        raise UnmappedBlockError(f"No manifest anchor matches a {b.lang} block; first line: {first_line!r}")
+    if len(matches) > 1:
+        raise UnmappedBlockError(f"Ambiguous: {[a for a, _, _ in matches]!r} all match one {b.lang} block")
+    _, dest, mode = matches[0]
+    return dest, mode
+
+
+def resolve_files(blocks: list[Block], manifest: list[tuple[str, str, str]]) -> list[tuple[str, str, str]]:
+    """Map every writable block to its destination. Raise if a block is unmapped
+    or ambiguous, or if a manifest anchor matches no block."""
+    resolved: list[tuple[str, str, str]] = []
+    hits = {anchor: 0 for anchor, _, _ in manifest}
+    for b in blocks:
+        if not is_writable_block(b):
+            continue
+        dest, mode = dest_for_block(b, manifest)
+        for anchor, d, m in manifest:
+            if anchor in b.body:
+                hits[anchor] += 1
+        resolved.append((dest, mode, b.body))
+    missing = [a for a, n in hits.items() if n == 0]
+    if missing:
+        raise UnmappedBlockError(f"Manifest anchors matched no block: {missing!r}")
+    return resolved
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `(cd tools/track-tester && uv run pytest libraries/tests/test_parse.py -v)`
+Expected: PASS (6 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/track-tester/libraries/assignment_blocks.py tools/track-tester/libraries/tests/test_parse.py tools/track-tester/pyproject.toml
+git commit -m "test: add aspire assignment fence parser + file resolver
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `AssignmentBlocks` Robot library (apply + get command)
+
+**Files:**
+- Modify: `tools/track-tester/libraries/assignment_blocks.py`
+- Create: `tools/track-tester/libraries/tests/test_apply.py`
+
+**Interfaces:**
+- Consumes: `parse_blocks`, `is_run_block`, `is_writable_block`, `command_lines`, `dest_for_block`, `resolve_files` from Task 1.
+- Produces (Robot keywords, class `AssignmentBlocks`):
+  - `Apply Challenge  assignment_path  start_dir  solution_dir  files_manifest  [skip_prefixes]` — process blocks in document order: run each `shell,run` command line (skipping `cd` by mutating cwd, and skipping any command starting with a skip prefix), and write/insert each writable block per the manifest. Calls `resolve_files` up front so an unmapped block fails the test immediately. Default `skip_prefixes=("aspire run", "docker run")`.
+  - `Get Command Containing  assignment_path  needle` → returns the first `shell,run` command line containing `needle` (raises `ValueError` if none). Used by ch5 to launch `aspire run` in the background and to run the `curl … /start` from the assignment text.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tools/track-tester/libraries/tests/test_apply.py`:
+
+```python
+import os
+import pytest
+from assignment_blocks import AssignmentBlocks, UnmappedBlockError
+
+SYNTH = """
+```shell,run
+mkdir sub
+```
+
+```csharp,copy
+// ANCHOR-FOO
+class Foo {}
+```
+
+```shell,run,copy
+cd sub
+```
+
+```shell,run
+touch made-in-sub.txt
+```
+
+```shell,run
+aspire run
+```
+"""
+
+
+def _write_md(tmp_path, text):
+    p = tmp_path / "assignment.md"
+    p.write_text(text)
+    return str(p)
+
+
+def test_apply_writes_files_runs_commands_tracks_cd_and_skips(tmp_path):
+    md = _write_md(tmp_path, SYNTH)
+    manifest = [("ANCHOR-FOO", "sub/Foo.cs", "write")]
+    AssignmentBlocks().apply_challenge(md, str(tmp_path), str(tmp_path), manifest)
+    # mkdir ran, file written under solution_dir
+    assert (tmp_path / "sub" / "Foo.cs").read_text().strip().endswith("class Foo {}")
+    # `cd sub` was honoured: touch created the file inside sub/
+    assert (tmp_path / "sub" / "made-in-sub.txt").exists()
+    # `aspire run` was skipped (no error, nothing to assert beyond no crash)
+
+
+def test_apply_raises_on_unmapped_block(tmp_path):
+    md = _write_md(tmp_path, "```csharp,copy\nclass Orphan {}\n```")
+    with pytest.raises(UnmappedBlockError):
+        AssignmentBlocks().apply_challenge(md, str(tmp_path), str(tmp_path), [])
+
+
+def test_get_command_containing(tmp_path):
+    md = _write_md(tmp_path, SYNTH)
+    assert AssignmentBlocks().get_command_containing(md, "aspire run") == "aspire run"
+    with pytest.raises(ValueError):
+        AssignmentBlocks().get_command_containing(md, "no-such-command")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `(cd tools/track-tester && uv run pytest libraries/tests/test_apply.py -v)`
+Expected: FAIL — `ImportError: cannot import name 'AssignmentBlocks'`.
+
+- [ ] **Step 3: Append the implementation**
+
+Append to `tools/track-tester/libraries/assignment_blocks.py`:
+
+```python
+def _read(path: str) -> str:
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _write(path: str, body: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(body if body.endswith("\n") else body + "\n")
+
+
+def _resolve_cd(cwd: str, target: str) -> str:
+    return target if os.path.isabs(target) else os.path.normpath(os.path.join(cwd, target))
+
+
+def _run(command: str, cwd: str) -> None:
+    result = subprocess.run(command, shell=True, cwd=cwd, capture_output=True, text=True, timeout=600)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Command failed (rc={result.returncode}) in {cwd}: {command}\n"
+            f"{result.stdout}\n{result.stderr}"
+        )
+
+
+def _apply_block(solution_dir: str, dest: str, mode: str, body: str) -> None:
+    path = os.path.join(solution_dir, dest)
+    if mode == "write":
+        _write(path, body)
+    elif mode.startswith("insert_before:"):
+        marker = mode.split(":", 1)[1]
+        content = _read(path)
+        if body.strip() in content:
+            return  # idempotent
+        snippet = body if body.endswith("\n") else body + "\n"
+        _write(path, content.replace(marker, snippet + marker, 1))
+    else:
+        raise ValueError(f"Unknown manifest mode: {mode!r}")
+
+
+class AssignmentBlocks:
+    """Robot Framework library that reconstructs the aspire app from an assignment."""
+
+    ROBOT_LIBRARY_SCOPE = "GLOBAL"
+
+    def apply_challenge(self, assignment_path, start_dir, solution_dir,
+                        files_manifest, skip_prefixes=("aspire run", "docker run")):
+        blocks = parse_blocks(_read(assignment_path))
+        resolve_files(blocks, files_manifest)  # fail-loud coverage check up front
+        cwd = start_dir
+        for b in blocks:
+            if is_run_block(b):
+                for cmd in command_lines(b.body):
+                    if any(cmd.startswith(p) for p in skip_prefixes):
+                        continue
+                    if cmd.startswith("cd "):
+                        cwd = _resolve_cd(cwd, cmd[3:].strip())
+                        continue
+                    _run(cmd, cwd)
+            elif is_writable_block(b):
+                dest, mode = dest_for_block(b, files_manifest)
+                _apply_block(solution_dir, dest, mode, b.body)
+
+    def get_command_containing(self, assignment_path, needle):
+        for b in parse_blocks(_read(assignment_path)):
+            if not is_run_block(b):
+                continue
+            for cmd in command_lines(b.body):
+                if needle in cmd:
+                    return cmd
+        raise ValueError(f"No run command containing {needle!r} in {assignment_path}")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `(cd tools/track-tester && uv run pytest libraries/tests/test_apply.py -v)`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/track-tester/libraries/assignment_blocks.py tools/track-tester/libraries/tests/test_apply.py
+git commit -m "feat: add AssignmentBlocks Robot library (apply + get command)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Variables + per-challenge manifests (validated against real assignments)
+
+**Files:**
+- Create: `tools/track-tester/variables/dapr_workflow_aspire.py`
+- Create: `tools/track-tester/libraries/tests/test_manifest.py`
+
+**Interfaces:**
+- Consumes: `parse_blocks`, `resolve_files` from Task 1.
+- Produces (module-level, imported by the suite via `Variables` and by the manifest test):
+  - `APISERVICE_URL = "http://localhost:5411/"`
+  - `STATUS_URL = "http://localhost:5411/status/mission-001"`
+  - `EXPECTED_STARDATE = '"starDate":"41153.7"'`
+  - `MANIFEST_CH2`, `MANIFEST_CH3`, `MANIFEST_CH4` — each a `list[tuple[anchor, dest, mode]]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tools/track-tester/libraries/tests/test_manifest.py`:
+
+```python
+import os
+from assignment_blocks import parse_blocks, resolve_files
+from dapr_workflow_aspire import MANIFEST_CH2, MANIFEST_CH3, MANIFEST_CH4
+
+# libraries/tests/ -> tools/track-tester/libraries/tests -> repo root is 4 up.
+_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
+
+
+def _assignment(challenge):
+    return os.path.join(_REPO, "dapr-workflow-aspire", challenge, "assignment.md")
+
+
+def _resolve(challenge, manifest):
+    with open(_assignment(challenge), encoding="utf-8") as fh:
+        return resolve_files(parse_blocks(fh.read()), manifest)
+
+
+def test_ch2_manifest_matches_real_assignment():
+    assert len(_resolve("2-project-creation", MANIFEST_CH2)) == 1
+
+
+def test_ch3_manifest_matches_real_assignment():
+    assert len(_resolve("3-workflow-definition", MANIFEST_CH3)) == 6
+
+
+def test_ch4_manifest_matches_real_assignment():
+    assert len(_resolve("4-apphost-resources", MANIFEST_CH4)) == 4
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `(cd tools/track-tester && uv run pytest libraries/tests/test_manifest.py -v)`
+Expected: FAIL — `ModuleNotFoundError: No module named 'dapr_workflow_aspire'`.
+
+- [ ] **Step 3: Write the variables/manifest module**
+
+Create `tools/track-tester/variables/dapr_workflow_aspire.py`:
+
+```python
+"""Variables and block->file manifests for the dapr-workflow-aspire suite.
+
+Each manifest entry is (anchor, dest, mode):
+  - anchor: a substring unique to the assignment's ,copy block body
+  - dest:   path relative to the EnterpriseDiagnostics solution root
+  - mode:   "write" (whole file) or "insert_before:<marker>" (splice into a file)
+"""
+
+APISERVICE_URL = "http://localhost:5411/"
+STATUS_URL = "http://localhost:5411/status/mission-001"
+EXPECTED_STARDATE = '"starDate":"41153.7"'
+
+MANIFEST_CH2 = [
+    (
+        '"$schema": "https://json.schemastore.org/launchsettings.json"',
+        "EnterpriseDiagnostics.AppHost/Properties/launchSettings.json",
+        "write",
+    ),
+]
+
+MANIFEST_CH3 = [
+    ("class DiagnoseSubsystemActivity",
+     "EnterpriseDiagnostics.ApiService/Activities/DiagnoseSubsystemActivity.cs", "write"),
+    ("class NotifyBridgeActivity",
+     "EnterpriseDiagnostics.ApiService/Activities/NotifyBridgeActivity.cs", "write"),
+    ("class PrioritizeDiagnosticsActivity",
+     "EnterpriseDiagnostics.ApiService/Activities/PrioritizeDiagnosticsActivity.cs", "write"),
+    ("namespace EnterpriseDiagnostics.Models",
+     "EnterpriseDiagnostics.ApiService/Models/Models.cs", "write"),
+    ("class EnterpriseDiagnosticsWorkflow",
+     "EnterpriseDiagnostics.ApiService/Workflows/EnterpriseDiagnosticsWorkflow.cs", "write"),
+    ("builder.Services.AddDaprWorkflow",
+     "EnterpriseDiagnostics.ApiService/Program.cs", "write"),
+]
+
+MANIFEST_CH4 = [
+    ("name: workflow-state",
+     "EnterpriseDiagnostics.AppHost/Resources/dapr/workflow-state.yaml", "write"),
+    ("name: diagrid-dashboard-store",
+     "EnterpriseDiagnostics.AppHost/Resources/dapr/diagrid-dashboard-components/diagrid-dashboard-state.yaml", "write"),
+    ("<Content Include=\"Resources",
+     "EnterpriseDiagnostics.AppHost/EnterpriseDiagnostics.AppHost.csproj", "insert_before:</Project>"),
+    ("using CommunityToolkit.Aspire.Hosting.Dapr",
+     "EnterpriseDiagnostics.AppHost/AppHost.cs", "write"),
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `(cd tools/track-tester && uv run pytest libraries/tests/test_manifest.py -v)`
+Expected: PASS (3 passed). If a manifest test raises `UnmappedBlockError`, an anchor no longer matches its assignment block (real drift or a typo) — fix the anchor to match the assignment, do NOT edit the assignment.
+
+- [ ] **Step 5: Run the full pytest suite**
+
+Run: `(cd tools/track-tester && uv run pytest -v)`
+Expected: PASS — the existing docsync tests plus the new parse/apply/manifest tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/track-tester/variables/dapr_workflow_aspire.py tools/track-tester/libraries/tests/test_manifest.py
+git commit -m "feat: add aspire variables and per-challenge block manifests
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: The cumulative Robot suite
+
+**Files:**
+- Create: `dapr-workflow-aspire/tests/challenge.robot`
+
+**Interfaces:**
+- Consumes: `AssignmentBlocks` keywords (`Apply Challenge`, `Get Command Containing`) from Task 2; `APISERVICE_URL`, `STATUS_URL`, `EXPECTED_STARDATE`, `MANIFEST_CH2/3/4` from Task 3; `Start Background Process`, `Wait Until App Responds`, `Wait Until Command Output Contains`, `Run And Expect RC Zero`, `Stop Process With SIGINT` from the existing `resources/workflow.resource` + `resources/dapr.resource`.
+- Produces: four ordered test cases sharing `${WORKDIR}` / `${SOLUTION_DIR}`.
+
+- [ ] **Step 1: Write the suite**
+
+Create `dapr-workflow-aspire/tests/challenge.robot`:
+
+```robotframework
+*** Settings ***
+Name              Dapr Workflow Aspire
+Documentation     Drift test for dapr-workflow-aspire: reconstruct the build-it-live
+...               app from the assignments, build it, run it, assert the workflow completes.
+Library           ../../tools/track-tester/libraries/assignment_blocks.py
+Resource          ../../tools/track-tester/resources/workflow.resource
+Variables         ../../tools/track-tester/variables/dapr_workflow_aspire.py
+Suite Setup       Prepare Workdir
+Suite Teardown    Terminate All Processes    kill=True
+
+*** Variables ***
+${WORKDIR}        ${TEMPDIR}${/}eds-track
+${SOLUTION_DIR}   ${WORKDIR}${/}EnterpriseDiagnostics
+${LOG}            ${TEMPDIR}/dapr-workflow-aspire.log
+${ASSIGN_2}       ${CURDIR}/../2-project-creation/assignment.md
+${ASSIGN_3}       ${CURDIR}/../3-workflow-definition/assignment.md
+${ASSIGN_4}       ${CURDIR}/../4-apphost-resources/assignment.md
+${ASSIGN_5}       ${CURDIR}/../5-run-application/assignment.md
+
+*** Keywords ***
+Prepare Workdir
+    # Start from a clean working directory so reruns don't collide with a stale scaffold.
+    Remove Directory    ${WORKDIR}    recursive=True
+    Create Directory    ${WORKDIR}
+
+*** Test Cases ***
+Ch2 Scaffold And Build
+    # Scaffold runs in ${WORKDIR}; the assignment's `cd EnterpriseDiagnostics`
+    # moves into the solution. Writes launchSettings.json, adds the pinned NuGet
+    # packages, and builds. `aspire run` is skipped (launched only in Ch5).
+    Apply Challenge    ${ASSIGN_2}    ${WORKDIR}    ${SOLUTION_DIR}    ${MANIFEST_CH2}
+    File Should Contain
+    ...    ${SOLUTION_DIR}/EnterpriseDiagnostics.ApiService/EnterpriseDiagnostics.ApiService.csproj
+    ...    Dapr.Workflow
+
+Ch3 Workflow Build
+    # Creates the Models/Workflows/Activities folders + files and rebuilds.
+    Apply Challenge    ${ASSIGN_3}    ${SOLUTION_DIR}    ${SOLUTION_DIR}    ${MANIFEST_CH3}
+
+Ch4 AppHost Build
+    # Writes the two Dapr component files, splices the <Content> item group into the
+    # AppHost csproj, replaces AppHost.cs, and rebuilds.
+    Apply Challenge    ${ASSIGN_4}    ${SOLUTION_DIR}    ${SOLUTION_DIR}    ${MANIFEST_CH4}
+
+Ch5 Run And Assert
+    [Teardown]    Stop Process With SIGINT    app
+    # Launch `aspire run` (from the assignment) in the background; it starts the
+    # ApiService + its Dapr sidecar. Skip the diagrid-dashboard docker step.
+    ${aspire}=    Get Command Containing    ${ASSIGN_5}    aspire run
+    Start Background Process    ${aspire}    ${LOG}    app    cwd=${SOLUTION_DIR}
+    Wait Until App Responds    ${APISERVICE_URL}    timeout=240s
+    # Start the workflow with the assignment's exact curl, then poll until the
+    # output echoes the input stardate (present only once the workflow completes).
+    ${start}=    Get Command Containing    ${ASSIGN_5}    /start
+    Run And Expect RC Zero    ${start}
+    Wait Until Command Output Contains    curl -s ${STATUS_URL}    ${EXPECTED_STARDATE}    timeout=120s
+```
+
+- [ ] **Step 2: Validate the suite resolves (no runtime env needed)**
+
+Run: `(cd tools/track-tester && uv run robot --dryrun ../../dapr-workflow-aspire/tests/challenge.robot)`
+Expected: PASS — all keywords/variables/imports resolve (`4 tests, 4 passed` in dry-run).
+
+- [ ] **Step 3: Full run (requires .NET 10 + Aspire CLI + templates + Docker + `dapr init`)**
+
+> Only run this where the runtime is available (locally with the stack installed, or in CI via Task 6). If your machine lacks .NET 10 / Aspire, skip to the commit — CI is the authoritative gate for the full run (mirrors the note in `MEMORY.md` about the .NET runtime being an environment concern, not a track bug).
+
+Run: `(cd tools/track-tester && uv run robot --outputdir results/aspire ../../dapr-workflow-aspire/tests/challenge.robot)`
+Expected: PASS — `4 tests, 4 passed`. Open `results/aspire/log.html` on failure.
+
+Two things to confirm here and adjust if needed (see spec "Deferred to implementation"):
+  1. **Readiness / completion.** If `/status/mission-001` never shows `"starDate":"41153.7"`, inspect the raw response (`curl -s http://localhost:5411/status/mission-001`) — the completion signal may be a `state` runtime-status field instead; update `EXPECTED_STARDATE` / the poll accordingly. If the app is slow to bind `:5411`, raise the `Wait Until App Responds` timeout.
+  2. **Aspire startup.** If `aspire run` fails because the ApiService port isn't `5411`, re-check that ch4's `AppHost.cs` `WithHttpEndpoint(port: 5411, ...)` was applied.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dapr-workflow-aspire/tests/challenge.robot
+git commit -m "feat: add cumulative Robot suite for dapr-workflow-aspire
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: CI sandbox setup script
+
+**Files:**
+- Create: `tools/track-tester/ci/setup-dapr-workflow-aspire.sh`
+
+**Interfaces:**
+- Produces: an executable script that installs `uv`, the Dapr CLI, and runs `dapr init` (providing the `dapr_redis` state store the workflow uses). .NET 10, the Aspire CLI, and the Aspire templates are provisioned by the CI workflow's own steps (Task 6), not here. No diagrid-dashboard pull.
+
+- [ ] **Step 1: Write the script**
+
+Create `tools/track-tester/ci/setup-dapr-workflow-aspire.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Reproduce the dapr-workflow-aspire sandbox environment in CI.
+# The track builds the app live from the assignments, so there is no repo to
+# clone. This script provisions the runtime bits the suite needs at test time:
+# uv (to run robot), the Dapr CLI, and `dapr init` (the workflow state store
+# points at the dapr_redis container it starts). .NET 10 + the Aspire CLI and
+# project templates are installed by the workflow's own steps. The diagrid
+# dashboard is NOT pulled — the suite does not run it.
+set -euo pipefail
+
+# 1. Install uv (used to run robot).
+if ! command -v uv >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  export PATH="$HOME/.local/bin:$PATH"
+  echo "$HOME/.local/bin" >> "${GITHUB_PATH:-/dev/null}"
+fi
+
+# 2. Install the Dapr CLI from master (matching the track's _setup, which does
+#    not pin a version) and initialise Dapr (starts dapr_redis etc.).
+if ! command -v dapr >/dev/null 2>&1; then
+  curl -fsSL https://raw.githubusercontent.com/dapr/cli/master/install/install.sh | /bin/bash
+fi
+dapr uninstall --all >/dev/null || true
+dapr init
+
+echo "Setup complete."
+```
+
+- [ ] **Step 2: Verify the script is syntactically valid**
+
+Run: `bash -n tools/track-tester/ci/setup-dapr-workflow-aspire.sh && echo OK`
+Expected: `OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/track-tester/ci/setup-dapr-workflow-aspire.sh
+git commit -m "ci: add dapr-workflow-aspire sandbox setup script
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: CI workflow
+
+**Files:**
+- Create: `.github/workflows/test-dapr-workflow-aspire.yml`
+
+**Interfaces:**
+- Consumes: `tools/track-tester/ci/setup-dapr-workflow-aspire.sh` (Task 5); the suite `dapr-workflow-aspire/tests/challenge.robot` (Task 4).
+- Produces: a `build-and-run` job (single language) and a `report` job that opens/updates a `drift-report` issue on scheduled failure.
+
+- [ ] **Step 1: Write the workflow**
+
+Create `.github/workflows/test-dapr-workflow-aspire.yml`:
+
+```yaml
+name: Test dapr-workflow-aspire track
+
+on:
+  schedule:
+    - cron: '30 6 * * 2'   # Tuesdays 06:30 UTC (offset from dapr-workflow's Monday run)
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'dapr-workflow-aspire/**'
+      - 'tools/track-tester/**'
+      - '.github/workflows/test-dapr-workflow-aspire.yml'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  build-and-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Set up .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+      - name: Install Aspire CLI
+        run: |
+          curl -sSL https://aspire.dev/install.sh | bash
+          # The installer prints the install dir; add the common location to PATH.
+          echo "$HOME/.aspire/bin" >> "$GITHUB_PATH"
+      - name: Install Aspire project templates
+        # Provides `dotnet new aspire-starter`. If drift makes the scaffold fail,
+        # pin the version here to match the sandbox image (see spec deferred item).
+        run: dotnet new install Aspire.ProjectTemplates
+      - name: Setup Dapr sandbox
+        run: bash tools/track-tester/ci/setup-dapr-workflow-aspire.sh
+      - name: Sync harness
+        run: (cd tools/track-tester && uv sync)
+      - name: Run aspire track suite
+        run: |
+          cd tools/track-tester
+          mkdir -p results
+          uv run robot --outputdir results --name "dapr-workflow-aspire" \
+            ../../dapr-workflow-aspire/tests/challenge.robot
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: robot-aspire
+          path: tools/track-tester/results/
+
+  report:
+    needs: [build-and-run]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'Dapr Workflow Aspire track drift detected';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `The dapr-workflow-aspire drift test **failed**.`,
+              ``,
+              `- Run: ${runUrl}`,
+              `- Download the \`robot-aspire\` artifact and open \`report.html\` / \`log.html\` for the failing checkpoint.`,
+              ``,
+              `_This issue is updated automatically each run._`,
+            ].join('\n');
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: 'drift-report',
+            });
+            const match = existing.data.find(i => i.title === title);
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: match.number, body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels: ['drift-report'],
+              });
+            }
+```
+
+- [ ] **Step 2: Validate the workflow YAML**
+
+Run: `(cd tools/track-tester && uv run python -c "import yaml,sys; yaml.safe_load(open('../../.github/workflows/test-dapr-workflow-aspire.yml')); print('OK')")`
+Expected: `OK`. (If PyYAML is unavailable, use any local YAML linter; the file must parse.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/test-dapr-workflow-aspire.yml
+git commit -m "ci: add dapr-workflow-aspire drift test workflow
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 4: Push the branch and open a PR to trigger the workflow**
+
+Because the full suite needs .NET 10 + Aspire + Docker, CI is the authoritative gate. Open a PR (the `pull_request` paths filter matches `dapr-workflow-aspire/**` and `tools/track-tester/**`) and confirm the `build-and-run` job goes green. Resolve the two deferred items (Aspire CLI PATH, `aspire run`/`/status` behavior) against the real CI run, editing Task 4's suite and Task 6's Aspire steps as needed, then re-push.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Extract-from-assignment source model → Tasks 1–2 (parser + apply). ✓
+- Single cumulative suite, four checkpoints → Task 4. ✓
+- Full workflow run in ch5, skip dashboard → Task 4 (skip prefixes + orchestrated `aspire run`/curl). ✓
+- Manifest by content anchor → Task 3. ✓
+- Fail-loud coverage (no separate static checker; `check_doc_sync.py` untouched) → `resolve_files` in Task 1, enforced in `apply_challenge` Task 2, plus manifest pytest Task 3. ✓
+- `.csproj` `<Content>` insertion + NuGet adds → `insert_before` mode (Task 2/3) + run-blocks. ✓
+- CI setup script (uv, Dapr, `dapr init`, no dashboard) → Task 5. ✓
+- Single-job CI workflow + drift-report issue → Task 6. ✓
+- Deferred items (aspire readiness/`/status` shape, template provisioning, csproj mechanism) → surfaced in Task 4 Step 3 and Task 6 (csproj resolved concretely via `insert_before`). ✓
+- Non-goals (no assignment edits, no doc-sync change, .NET only, no ch1 suite) → honored throughout. ✓
+
+**Placeholder scan:** No "TBD/TODO"; every code step shows complete code; deferred items carry concrete starting commands + explicit verification, not blanks.
+
+**Type consistency:** `Block(lang, tags, body)`, `dest_for_block → (dest, mode)`, `resolve_files → [(dest, mode, body)]`, manifest entries are 3-tuples `(anchor, dest, mode)` everywhere (Tasks 1/2/3), `apply_challenge`/`get_command_containing` keyword names match between Task 2, Task 4, and the interface blocks. Consistent.

--- a/docs/superpowers/specs/2026-07-23-dapr-workflow-aspire-drift-tests-design.md
+++ b/docs/superpowers/specs/2026-07-23-dapr-workflow-aspire-drift-tests-design.md
@@ -1,0 +1,194 @@
+# dapr-workflow-aspire drift tests — design
+
+## Goal
+
+Add Robot Framework drift tests for the `dapr-workflow-aspire` track under the
+existing harness (`tools/track-tester/`). Because this track is **build-it-live**
+(the learner scaffolds and pastes every file from the assignments — there is no
+upstream repo to clone), the suite reconstructs the app by extracting the exact
+`,copy` / `,run` fenced blocks from the assignments, builds and runs it, and
+asserts the workflow completes. This catches drift in the tooling the assignment
+depends on: the `aspire-starter` template, the pinned NuGet versions, .NET 10,
+the Aspire CLI, Dapr, and the `dapr_redis` state store.
+
+## What makes this track different from dapr-workflow / dapr-101 (verified)
+
+- **Code source = the assignments themselves.** Every C#/JSON/YAML/XML file is
+  pasted from a `,copy` fenced block; every command is a `shell,run` /
+  `shell,run,copy` block. Nothing is cloned from `dapr/quickstarts`. The drift
+  signal is therefore *tooling* drift (template, package versions, SDK, CLI),
+  not upstream-code drift.
+- **Challenges are cumulative**, not independent. ch3's build needs ch2's
+  scaffold; ch4 needs ch3's code; ch5 runs the whole thing. This is one
+  continuous working directory, unlike dapr-workflow's per-challenge quickstart
+  folders.
+- **Single language (.NET only)** — no dotnet/java/python tag matrix.
+- **Aspire orchestrates the Dapr sidecar** (`builder.AddDapr()` +
+  `WithDaprSidecar` in `AppHost.cs`), rather than `dapr run -f .`. The ApiService
+  is pinned to `http://localhost:5411` via `WithHttpEndpoint(port: 5411)`. The
+  workflow state store (`Resources/dapr/workflow-state.yaml`) points at
+  `localhost:6379` — the `dapr_redis` container started by `dapr init`.
+- **ch1 (introduction) is pure reading** — no runnable commands, no suite.
+- **The diagrid-dashboard step in ch5 is read-only visualization** — it asserts
+  nothing about the workflow, so it is executed by neither the suite nor the
+  setup script (skipped by design).
+- **Fence tag is `shell`, not `bash`.** The current
+  `docsync/check_doc_sync.py` treats only `bash,run` as runnable, so it does not
+  recognize this track's blocks.
+
+## Key facts (from the assignments)
+
+- **Pinned versions** (drift-sensitive): `Dapr.Workflow 1.18.4`,
+  `Dapr.Workflow.Versioning 1.18.4`, `CommunityToolkit.Aspire.Hosting.Dapr
+  13.0.0`; `dotnet new aspire-starter` (the assignment explicitly says *not* to
+  upgrade Aspire).
+- **Scaffold:** `dotnet new aspire-starter -n EnterpriseDiagnostics -o
+  EnterpriseDiagnostics`, then all remaining commands run inside
+  `EnterpriseDiagnostics/`.
+- **Runtime prerequisites:** .NET 10 SDK, Aspire CLI, Dapr CLI + `dapr init`
+  (provides the `dapr_redis` container the workflow state store points at),
+  Docker daemon (for the Dapr containers).
+- **Workflow shape:** fan-out to three subsystem activities → prioritize →
+  conditionally notify the bridge. Activity results are randomized
+  (`Random.Shared`), so `Priority`/`Summary` vary run to run. The stable,
+  assertable facts are: the workflow reaches completion, and the output echoes
+  the input `starDate` (`41153.7`) and carries a `Priority` field.
+- **Interaction:** `curl -X POST http://localhost:5411/start` with
+  `{"id":"mission-001","starDate":"41153.7"}` → poll `GET
+  http://localhost:5411/status/mission-001`.
+
+## Architecture — extract, apply, run
+
+A single cumulative suite (`dapr-workflow-aspire/tests/challenge.robot`) drives
+four ordered checkpoint test cases in one working directory
+(`${TEMPDIR}/EnterpriseDiagnostics-track`). The cases must run in order and share
+state; each applies the next assignment's steps on top of the prior state:
+
+| Test case | Applies (from assignment.md) | Asserts |
+|---|---|---|
+| Ch2 Scaffold & Build | ch2 `shell,run` blocks (scaffold, `cd`, NuGet adds) + write `launchSettings.json` | `dotnet build` rc 0; ApiService `.csproj` carries the pinned Dapr package versions |
+| Ch3 Workflow Build | ch3 `mkdir`/`touch` blocks + write the 6 code files (3 activities, models, workflow, `Program.cs`) | `dotnet build` rc 0 |
+| Ch4 AppHost Build | ch4 write 2 component YAMLs, edit `.csproj`, replace `AppHost.cs` | `dotnet build` rc 0 |
+| Ch5 Run & Assert | `aspire run` (background) → `curl POST /start` → poll `GET /status/mission-001` | workflow reaches completion; output echoes `starDate 41153.7` and carries a `Priority` |
+
+### Extraction
+
+A Python library `tools/track-tester/libraries/assignment_blocks.py`, imported by
+the suite as a `Library`, does the reconstruction:
+
+- **Parse** fenced blocks from an `assignment.md`, capturing each block's info
+  string (e.g. `shell,run`, `csharp,copy`, `json,copy`, `yaml,copy`, `xml,copy`,
+  `text,nocopy`) and body.
+- **Run-blocks** (`shell,run` / `shell,run,copy`): execute in document order.
+  The harness tracks the `cd EnterpriseDiagnostics` (and any other `cd`) so
+  subsequent commands run in the right cwd. `,nocopy` blocks are display-only and
+  are never executed.
+- **File-blocks** (`,copy` blocks that are `csharp`/`json`/`yaml`/`xml`): write
+  the body to a destination path resolved from a **per-challenge manifest**.
+
+### Block → file manifest
+
+The destination for each file-block is described in prose, not machine-readable,
+so a manifest in `variables/dapr_workflow_aspire.py` maps blocks to targets.
+Entries are keyed on a **unique content anchor** (a substring the block body must
+contain) rather than an ordinal, so the mapping survives block reordering. For
+example:
+
+- body contains `class DiagnoseSubsystemActivity` →
+  `EnterpriseDiagnostics.ApiService/Activities/DiagnoseSubsystemActivity.cs`
+- body contains `namespace EnterpriseDiagnostics.Models` →
+  `EnterpriseDiagnostics.ApiService/Models/Models.cs`
+- body contains `"$schema": "https://json.schemastore.org/launchsettings.json"`
+  → `EnterpriseDiagnostics.AppHost/Properties/launchSettings.json`
+- body contains `name: workflow-state` →
+  `EnterpriseDiagnostics.AppHost/Resources/dapr/workflow-state.yaml`
+
+The `.csproj` `<Content>` item-group edit (ch4) and the NuGet `dotnet add`
+commands (ch2) are *insertions/commands*, not whole-file replacements, and are
+handled as run-blocks or a targeted insert keyword — resolved in implementation.
+
+## Components (new files)
+
+- **Suite** (new): `dapr-workflow-aspire/tests/challenge.robot` — the single
+  cumulative suite, four ordered test cases, `Suite Teardown` terminating the
+  `aspire run` process tree.
+- **Extraction library** (new):
+  `tools/track-tester/libraries/assignment_blocks.py` — fence parser + apply
+  logic, exposed as Robot keywords (e.g. `Apply Challenge`, `Assert File
+  Contains`). Fails loud on an unmapped writable block (see "Coverage
+  enforcement" below), so manifest coverage is enforced by the run itself.
+- **Variables + manifest** (new):
+  `tools/track-tester/variables/dapr_workflow_aspire.py` — working-dir base,
+  ApiService port/URLs, expected values, and the per-challenge block→file
+  manifest.
+- **CI setup script** (new):
+  `tools/track-tester/ci/setup-dapr-workflow-aspire.sh` — reproduce the sandbox:
+  install uv, .NET 10 SDK, Aspire CLI, Dapr CLI, `dapr init`. No
+  diagrid-dashboard pull (dashboard not run). Mirrors the shape of
+  `setup-dapr-workflow.sh`.
+- **CI workflow** (new): `.github/workflows/test-dapr-workflow-aspire.yml` —
+  see below.
+- **Reuse** `resources/workflow.resource` + `resources/dapr.resource` where they
+  fit: `Start Background Process`, `Wait Until App Responds`, `Wait Until Command
+  Output Contains`, `Run And Expect RC Zero`, `Stop Process With SIGINT`.
+
+## Coverage enforcement (fail-loud extraction)
+
+The failure mode unique to extraction: a **new `,copy` file-block added to an
+assignment that the manifest does not map** would be silently skipped, and the
+build might still pass — hiding real drift.
+
+Reusing `check_doc_sync.py` (even extended to accept `shell` fences) does **not**
+guard this, because its whole model is wrong for an extraction-based track: it
+asserts each run-command string appears *verbatim in the suite file*, but here
+the commands are extracted and run at runtime and never appear in
+`challenge.robot` (wrong haystack), and it only inspects run-commands, never the
+file-content blocks that carry the real risk.
+
+Rather than add a separate static checker, the **extractor enforces coverage
+itself**: when applying a challenge, if it encounters a writable `,copy` block
+(`csharp`/`json`/`yaml`/`xml`) whose anchor is not in the manifest, it raises and
+the Robot test fails with an explicit "unmapped block" message. This catches the
+exact risk as a side effect of the run — no extra script, no extra CI job. The
+only thing given up is a fast standalone signal that runs without the full
+.NET/Aspire/Docker stack; since the suite runs in CI on the same triggers, that
+loss is small.
+
+`check_doc_sync.py` stays **unchanged** (parity with dapr-101/dapr-workflow); it
+is simply not used for this track.
+
+## CI workflow (`test-dapr-workflow-aspire.yml`)
+
+Structurally like `test-dapr-workflow.yml`, but single-language:
+
+- **Triggers:** weekly schedule (offset from the other tracks'),
+  `workflow_dispatch`, and `pull_request` filtered on `dapr-workflow-aspire/**`
+  and `tools/track-tester/**` (plus the workflow file itself).
+- **`build-and-run` job** (no matrix): `setup-dotnet` for .NET 10, install the
+  Aspire CLI, run `setup-dapr-workflow-aspire.sh` (Dapr + `dapr init`; Docker is
+  present on `ubuntu-latest`), `uv sync`, then run the single suite. Upload the
+  Robot `results/` as an artifact.
+- **`report` job:** on scheduled failure, open/update a `drift-report` issue,
+  reusing the pattern in `test-dapr-workflow.yml`.
+
+## Deliberately deferred to implementation (TDD)
+
+Resolved by running locally against a real .NET 10 + Aspire + Dapr environment:
+
+1. **`aspire run` readiness + `/status` shape.** Exact readiness probe for the
+   Aspire-orchestrated ApiService on `:5411`, startup timeout, and the JSON
+   shape of `GET /status/{id}` used for the completion assertion (the app returns
+   `{ state, output }`; confirm whether to assert on a `state` runtime-status
+   field or on `output.StarDate`).
+2. **Aspire template provisioning in CI.** Whether `dotnet new aspire-starter`
+   needs the Aspire project templates installed explicitly in the setup script
+   (and at which version) or is provided by the .NET 10 SDK / Aspire CLI.
+3. **`.csproj` edits.** The exact keyword/mechanism for the ch2 NuGet adds and
+   the ch4 `<Content>` item-group insertion (run-block vs. targeted insert).
+
+## Non-goals
+
+- No dashboard execution, no multi-language matrix, no ch1 suite.
+- No changes to `check_doc_sync.py` or to the existing dapr-101 / dapr-workflow
+  suites.
+- No changes to the `dapr-workflow-aspire` assignment content.

--- a/tools/track-tester/ci/setup-dapr-workflow-aspire.sh
+++ b/tools/track-tester/ci/setup-dapr-workflow-aspire.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Reproduce the dapr-workflow-aspire sandbox environment in CI.
+# The track builds the app live from the assignments, so there is no repo to
+# clone. This script provisions the runtime bits the suite needs at test time:
+# uv (to run robot), the Dapr CLI, and `dapr init` (the workflow state store
+# points at the dapr_redis container it starts). .NET 10 + the Aspire CLI and
+# project templates are installed by the workflow's own steps. The diagrid
+# dashboard is NOT pulled — the suite does not run it.
+set -euo pipefail
+
+# 1. Install uv (used to run robot).
+if ! command -v uv >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  export PATH="$HOME/.local/bin:$PATH"
+  echo "$HOME/.local/bin" >> "${GITHUB_PATH:-/dev/null}"
+fi
+
+# 2. Install the Dapr CLI from master (matching the track's _setup, which does
+#    not pin a version) and initialise Dapr (starts dapr_redis etc.).
+if ! command -v dapr >/dev/null 2>&1; then
+  curl -fsSL https://raw.githubusercontent.com/dapr/cli/master/install/install.sh | /bin/bash
+fi
+dapr uninstall --all >/dev/null || true
+dapr init
+
+echo "Setup complete."

--- a/tools/track-tester/libraries/assignment_blocks.py
+++ b/tools/track-tester/libraries/assignment_blocks.py
@@ -105,3 +105,75 @@ def resolve_files(blocks: list[Block], manifest: list[tuple[str, str, str]]) -> 
     if over:
         raise UnmappedBlockError(f"Manifest anchors matched multiple blocks: {over!r}")
     return resolved
+
+
+def _read(path: str) -> str:
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _write(path: str, body: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(body if body.endswith("\n") else body + "\n")
+
+
+def _resolve_cd(cwd: str, target: str) -> str:
+    return target if os.path.isabs(target) else os.path.normpath(os.path.join(cwd, target))
+
+
+def _run(command: str, cwd: str) -> None:
+    result = subprocess.run(command, shell=True, cwd=cwd, capture_output=True, text=True, timeout=600)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Command failed (rc={result.returncode}) in {cwd}: {command}\n"
+            f"{result.stdout}\n{result.stderr}"
+        )
+
+
+def _apply_block(solution_dir: str, dest: str, mode: str, body: str) -> None:
+    path = os.path.join(solution_dir, dest)
+    if mode == "write":
+        _write(path, body)
+    elif mode.startswith("insert_before:"):
+        marker = mode.split(":", 1)[1]
+        content = _read(path)
+        if body.strip() in content:
+            return  # idempotent
+        snippet = body if body.endswith("\n") else body + "\n"
+        _write(path, content.replace(marker, snippet + marker, 1))
+    else:
+        raise ValueError(f"Unknown manifest mode: {mode!r}")
+
+
+class AssignmentBlocks:
+    """Robot Framework library that reconstructs the aspire app from an assignment."""
+
+    ROBOT_LIBRARY_SCOPE = "GLOBAL"
+
+    def apply_challenge(self, assignment_path, start_dir, solution_dir,
+                        files_manifest, skip_prefixes=("aspire run", "docker run")):
+        blocks = parse_blocks(_read(assignment_path))
+        resolve_files(blocks, files_manifest)  # fail-loud coverage check up front
+        cwd = start_dir
+        for b in blocks:
+            if is_run_block(b):
+                for cmd in command_lines(b.body):
+                    if any(cmd.startswith(p) for p in skip_prefixes):
+                        continue
+                    if cmd.startswith("cd "):
+                        cwd = _resolve_cd(cwd, cmd[3:].strip())
+                        continue
+                    _run(cmd, cwd)
+            elif is_writable_block(b):
+                dest, mode = dest_for_block(b, files_manifest)
+                _apply_block(solution_dir, dest, mode, b.body)
+
+    def get_command_containing(self, assignment_path, needle):
+        for b in parse_blocks(_read(assignment_path)):
+            if not is_run_block(b):
+                continue
+            for cmd in command_lines(b.body):
+                if needle in cmd:
+                    return cmd
+        raise ValueError(f"No run command containing {needle!r} in {assignment_path}")

--- a/tools/track-tester/libraries/assignment_blocks.py
+++ b/tools/track-tester/libraries/assignment_blocks.py
@@ -1,0 +1,104 @@
+"""Extract and apply a dapr-workflow-aspire assignment's build-it-live steps.
+
+The track has no upstream repo: every file the learner creates is pasted from a
+``,copy`` fenced block and every command is a ``shell,run`` block. This module
+parses those blocks so the Robot suite can reconstruct the app exactly as the
+assignment describes, catching drift in the tooling the assignment depends on.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+
+_FENCE_RE = re.compile(r"^```([^\n`]*)$")
+_WRITABLE_LANGS = {"csharp", "json", "yaml", "xml"}
+
+
+@dataclass(frozen=True)
+class Block:
+    lang: str              # first token of the info string, e.g. "shell", "csharp"
+    tags: tuple[str, ...]  # remaining comma flags, e.g. ("run",), ("copy",)
+    body: str              # block contents, fences stripped
+
+
+def parse_blocks(md_text: str) -> list[Block]:
+    blocks: list[Block] = []
+    in_fence = False
+    info = ""
+    lines: list[str] = []
+    for line in md_text.splitlines():
+        fence = _FENCE_RE.match(line.strip())
+        if fence is not None:
+            if not in_fence:
+                in_fence, info, lines = True, fence.group(1), []
+            else:
+                parts = [p.strip() for p in info.split(",") if p.strip()]
+                lang = parts[0] if parts else ""
+                blocks.append(Block(lang=lang, tags=tuple(parts[1:]), body="\n".join(lines)))
+                in_fence = False
+        elif in_fence:
+            lines.append(line)
+    return blocks
+
+
+def is_run_block(b: Block) -> bool:
+    return b.lang == "shell" and "run" in b.tags
+
+
+def is_writable_block(b: Block) -> bool:
+    return b.lang in _WRITABLE_LANGS and "copy" in b.tags
+
+
+def command_lines(body: str) -> list[str]:
+    """Logical command lines: join trailing-backslash continuations, drop blank
+    and comment lines."""
+    out: list[str] = []
+    buf = ""
+    for raw in body.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.endswith("\\"):
+            buf += line[:-1].rstrip() + " "
+        else:
+            out.append((buf + line).strip())
+            buf = ""
+    if buf.strip():
+        out.append(buf.strip())
+    return out
+
+
+class UnmappedBlockError(Exception):
+    """A writable block has no (or an ambiguous) manifest mapping."""
+
+
+def dest_for_block(b: Block, manifest: list[tuple[str, str, str]]) -> tuple[str, str]:
+    matches = [(anchor, dest, mode) for anchor, dest, mode in manifest if anchor in b.body]
+    first_line = b.body.splitlines()[0] if b.body else "<empty>"
+    if not matches:
+        raise UnmappedBlockError(f"No manifest anchor matches a {b.lang} block; first line: {first_line!r}")
+    if len(matches) > 1:
+        raise UnmappedBlockError(f"Ambiguous: {[a for a, _, _ in matches]!r} all match one {b.lang} block")
+    _, dest, mode = matches[0]
+    return dest, mode
+
+
+def resolve_files(blocks: list[Block], manifest: list[tuple[str, str, str]]) -> list[tuple[str, str, str]]:
+    """Map every writable block to its destination. Raise if a block is unmapped
+    or ambiguous, or if a manifest anchor matches no block."""
+    resolved: list[tuple[str, str, str]] = []
+    hits = {anchor: 0 for anchor, _, _ in manifest}
+    for b in blocks:
+        if not is_writable_block(b):
+            continue
+        dest, mode = dest_for_block(b, manifest)
+        for anchor, d, m in manifest:
+            if anchor in b.body:
+                hits[anchor] += 1
+        resolved.append((dest, mode, b.body))
+    missing = [a for a, n in hits.items() if n == 0]
+    if missing:
+        raise UnmappedBlockError(f"Manifest anchors matched no block: {missing!r}")
+    return resolved

--- a/tools/track-tester/libraries/assignment_blocks.py
+++ b/tools/track-tester/libraries/assignment_blocks.py
@@ -150,6 +150,7 @@ class AssignmentBlocks:
     """Robot Framework library that reconstructs the aspire app from an assignment."""
 
     ROBOT_LIBRARY_SCOPE = "GLOBAL"
+    ROBOT_AUTO_KEYWORDS = True  # RF: class name != module name, so mark this the library class
 
     def apply_challenge(self, assignment_path, start_dir, solution_dir,
                         files_manifest, skip_prefixes=("aspire run", "docker run")):

--- a/tools/track-tester/libraries/assignment_blocks.py
+++ b/tools/track-tester/libraries/assignment_blocks.py
@@ -101,4 +101,7 @@ def resolve_files(blocks: list[Block], manifest: list[tuple[str, str, str]]) -> 
     missing = [a for a, n in hits.items() if n == 0]
     if missing:
         raise UnmappedBlockError(f"Manifest anchors matched no block: {missing!r}")
+    over = [a for a, n in hits.items() if n > 1]
+    if over:
+        raise UnmappedBlockError(f"Manifest anchors matched multiple blocks: {over!r}")
     return resolved

--- a/tools/track-tester/libraries/tests/test_apply.py
+++ b/tools/track-tester/libraries/tests/test_apply.py
@@ -1,0 +1,56 @@
+import os
+import pytest
+from assignment_blocks import AssignmentBlocks, UnmappedBlockError
+
+SYNTH = """
+```shell,run
+mkdir sub
+```
+
+```csharp,copy
+// ANCHOR-FOO
+class Foo {}
+```
+
+```shell,run,copy
+cd sub
+```
+
+```shell,run
+touch made-in-sub.txt
+```
+
+```shell,run
+aspire run
+```
+"""
+
+
+def _write_md(tmp_path, text):
+    p = tmp_path / "assignment.md"
+    p.write_text(text)
+    return str(p)
+
+
+def test_apply_writes_files_runs_commands_tracks_cd_and_skips(tmp_path):
+    md = _write_md(tmp_path, SYNTH)
+    manifest = [("ANCHOR-FOO", "sub/Foo.cs", "write")]
+    AssignmentBlocks().apply_challenge(md, str(tmp_path), str(tmp_path), manifest)
+    # mkdir ran, file written under solution_dir
+    assert (tmp_path / "sub" / "Foo.cs").read_text().strip().endswith("class Foo {}")
+    # `cd sub` was honoured: touch created the file inside sub/
+    assert (tmp_path / "sub" / "made-in-sub.txt").exists()
+    # `aspire run` was skipped (no error, nothing to assert beyond no crash)
+
+
+def test_apply_raises_on_unmapped_block(tmp_path):
+    md = _write_md(tmp_path, "```csharp,copy\nclass Orphan {}\n```")
+    with pytest.raises(UnmappedBlockError):
+        AssignmentBlocks().apply_challenge(md, str(tmp_path), str(tmp_path), [])
+
+
+def test_get_command_containing(tmp_path):
+    md = _write_md(tmp_path, SYNTH)
+    assert AssignmentBlocks().get_command_containing(md, "aspire run") == "aspire run"
+    with pytest.raises(ValueError):
+        AssignmentBlocks().get_command_containing(md, "no-such-command")

--- a/tools/track-tester/libraries/tests/test_manifest.py
+++ b/tools/track-tester/libraries/tests/test_manifest.py
@@ -1,0 +1,27 @@
+import os
+from assignment_blocks import parse_blocks, resolve_files
+from dapr_workflow_aspire import MANIFEST_CH2, MANIFEST_CH3, MANIFEST_CH4
+
+# libraries/tests/ -> tools/track-tester/libraries/tests -> repo root is 4 up.
+_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
+
+
+def _assignment(challenge):
+    return os.path.join(_REPO, "dapr-workflow-aspire", challenge, "assignment.md")
+
+
+def _resolve(challenge, manifest):
+    with open(_assignment(challenge), encoding="utf-8") as fh:
+        return resolve_files(parse_blocks(fh.read()), manifest)
+
+
+def test_ch2_manifest_matches_real_assignment():
+    assert len(_resolve("2-project-creation", MANIFEST_CH2)) == 1
+
+
+def test_ch3_manifest_matches_real_assignment():
+    assert len(_resolve("3-workflow-definition", MANIFEST_CH3)) == 6
+
+
+def test_ch4_manifest_matches_real_assignment():
+    assert len(_resolve("4-apphost-resources", MANIFEST_CH4)) == 4

--- a/tools/track-tester/libraries/tests/test_parse.py
+++ b/tools/track-tester/libraries/tests/test_parse.py
@@ -1,0 +1,82 @@
+import pytest
+from assignment_blocks import (
+    Block,
+    parse_blocks,
+    is_run_block,
+    is_writable_block,
+    command_lines,
+    dest_for_block,
+    resolve_files,
+    UnmappedBlockError,
+)
+
+MD = """
+Intro.
+
+```shell,run
+dotnet new aspire-starter -n EnterpriseDiagnostics -o EnterpriseDiagnostics
+```
+
+```shell,run,copy
+cd EnterpriseDiagnostics
+```
+
+```json,copy
+{ "$schema": "https://json.schemastore.org/launchsettings.json" }
+```
+
+```text,nocopy
+display only, ignored
+```
+"""
+
+
+def test_parse_captures_lang_tags_body():
+    blocks = parse_blocks(MD)
+    assert [(b.lang, b.tags) for b in blocks] == [
+        ("shell", ("run",)),
+        ("shell", ("run", "copy")),
+        ("json", ("copy",)),
+        ("text", ("nocopy",)),
+    ]
+    assert blocks[0].body == "dotnet new aspire-starter -n EnterpriseDiagnostics -o EnterpriseDiagnostics"
+
+
+def test_classification():
+    blocks = parse_blocks(MD)
+    assert [is_run_block(b) for b in blocks] == [True, True, False, False]
+    assert [is_writable_block(b) for b in blocks] == [False, False, True, False]
+
+
+def test_command_lines_joins_continuations_and_drops_comments():
+    body = "# a comment\ndocker run -p 1:1 \\\n  -e X=y \\\n  image\n\ntouch f"
+    assert command_lines(body) == ["docker run -p 1:1 -e X=y image", "touch f"]
+
+
+def test_resolve_files_maps_by_anchor():
+    blocks = parse_blocks(MD)
+    manifest = [('"$schema": "https://json.schemastore.org/launchsettings.json"',
+                 "AppHost/Properties/launchSettings.json", "write")]
+    resolved = resolve_files(blocks, manifest)
+    assert len(resolved) == 1
+    dest, mode, body = resolved[0]
+    assert dest == "AppHost/Properties/launchSettings.json"
+    assert mode == "write"
+    assert "$schema" in body
+
+
+def test_resolve_files_raises_on_unmapped_block():
+    blocks = parse_blocks("```csharp,copy\nclass Orphan {}\n```")
+    with pytest.raises(UnmappedBlockError):
+        resolve_files(blocks, [])
+
+
+def test_resolve_files_raises_when_anchor_matches_nothing():
+    blocks = parse_blocks(MD)
+    manifest = [
+        ('"$schema": "https://json.schemastore.org/launchsettings.json"',
+         "AppHost/Properties/launchSettings.json", "write"),
+        ("anchor that is absent", "nowhere.cs", "write"),
+    ]
+    with pytest.raises(UnmappedBlockError):
+        resolve_files(blocks, manifest)

--- a/tools/track-tester/libraries/tests/test_parse.py
+++ b/tools/track-tester/libraries/tests/test_parse.py
@@ -80,3 +80,11 @@ def test_resolve_files_raises_when_anchor_matches_nothing():
     ]
     with pytest.raises(UnmappedBlockError):
         resolve_files(blocks, manifest)
+
+
+def test_resolve_files_raises_when_anchor_matches_multiple_blocks():
+    md = "```csharp,copy\nclass A { // SHARED\n}\n```\n\n```csharp,copy\nclass B { // SHARED\n}\n```"
+    blocks = parse_blocks(md)
+    manifest = [("SHARED", "Shared.cs", "write")]
+    with pytest.raises(UnmappedBlockError):
+        resolve_files(blocks, manifest)

--- a/tools/track-tester/pyproject.toml
+++ b/tools/track-tester/pyproject.toml
@@ -11,5 +11,5 @@ dependencies = [
 dev = ["pytest>=8"]
 
 [tool.pytest.ini_options]
-pythonpath = ["docsync"]
-testpaths = ["docsync/tests"]
+pythonpath = ["docsync", "libraries", "variables"]
+testpaths = ["docsync/tests", "libraries/tests"]

--- a/tools/track-tester/variables/dapr_workflow_aspire.py
+++ b/tools/track-tester/variables/dapr_workflow_aspire.py
@@ -1,0 +1,45 @@
+"""Variables and block->file manifests for the dapr-workflow-aspire suite.
+
+Each manifest entry is (anchor, dest, mode):
+  - anchor: a substring unique to the assignment's ,copy block body
+  - dest:   path relative to the EnterpriseDiagnostics solution root
+  - mode:   "write" (whole file) or "insert_before:<marker>" (splice into a file)
+"""
+
+APISERVICE_URL = "http://localhost:5411/"
+STATUS_URL = "http://localhost:5411/status/mission-001"
+EXPECTED_STARDATE = '"starDate":"41153.7"'
+
+MANIFEST_CH2 = [
+    (
+        '"$schema": "https://json.schemastore.org/launchsettings.json"',
+        "EnterpriseDiagnostics.AppHost/Properties/launchSettings.json",
+        "write",
+    ),
+]
+
+MANIFEST_CH3 = [
+    ("class DiagnoseSubsystemActivity",
+     "EnterpriseDiagnostics.ApiService/Activities/DiagnoseSubsystemActivity.cs", "write"),
+    ("class NotifyBridgeActivity",
+     "EnterpriseDiagnostics.ApiService/Activities/NotifyBridgeActivity.cs", "write"),
+    ("class PrioritizeDiagnosticsActivity",
+     "EnterpriseDiagnostics.ApiService/Activities/PrioritizeDiagnosticsActivity.cs", "write"),
+    ("namespace EnterpriseDiagnostics.Models",
+     "EnterpriseDiagnostics.ApiService/Models/Models.cs", "write"),
+    ("class EnterpriseDiagnosticsWorkflow",
+     "EnterpriseDiagnostics.ApiService/Workflows/EnterpriseDiagnosticsWorkflow.cs", "write"),
+    ("builder.Services.AddDaprWorkflow",
+     "EnterpriseDiagnostics.ApiService/Program.cs", "write"),
+]
+
+MANIFEST_CH4 = [
+    ("name: workflow-state",
+     "EnterpriseDiagnostics.AppHost/Resources/dapr/workflow-state.yaml", "write"),
+    ("name: diagrid-dashboard-store",
+     "EnterpriseDiagnostics.AppHost/Resources/dapr/diagrid-dashboard-components/diagrid-dashboard-state.yaml", "write"),
+    ("<Content Include=\"Resources",
+     "EnterpriseDiagnostics.AppHost/EnterpriseDiagnostics.AppHost.csproj", "insert_before:</Project>"),
+    ("using CommunityToolkit.Aspire.Hosting.Dapr",
+     "EnterpriseDiagnostics.AppHost/AppHost.cs", "write"),
+]


### PR DESCRIPTION
## What

Adds Robot Framework drift tests for the **`dapr-workflow-aspire`** track, extending the existing `tools/track-tester/` harness.

Because this track is **build-it-live** (the app code exists only inside the assignments' fenced `,copy` blocks — nothing is cloned from an upstream repo), the harness works differently from the `dapr-workflow` / `dapr-101` suites: it **extracts the exact `,copy`/`,run` blocks from each `assignment.md`**, reconstructs the app, builds it across cumulative checkpoints, and runs the workflow. The drift it catches is tooling drift — the `aspire-starter` template, the pinned Aspire template version, pinned NuGet versions, .NET 10, Dapr.

## How it's built

- **`tools/track-tester/libraries/assignment_blocks.py`** — pure fence parser + manifest-based file resolver (fails loud on any unmapped/ambiguous/over-matched `,copy` block), plus the `AssignmentBlocks` Robot library (`Apply Challenge`, `Get Command Containing`). It runs an assignment's `shell,run` commands in order (tracking `cd`, skipping `aspire run`/`docker run`) and writes/inserts its `,copy` blocks to manifest-mapped destinations.
- **`tools/track-tester/variables/dapr_workflow_aspire.py`** — endpoints, expected values, and the per-challenge block→file manifests (anchored on unique content substrings, so they survive block reordering).
- **`dapr-workflow-aspire/tests/challenge.robot`** — one cumulative suite, five ordered checkpoints:
  - **Ch1** — extract & run the pinned `dotnet new install Aspire.ProjectTemplates@13.3.5` from the assignment (the version that works in the sandbox; 13.4.* is intentionally avoided).
  - **Ch2** scaffold + build → **Ch3** workflow build → **Ch4** apphost build → **Ch5** `aspire run` + assert the workflow completes (`"starDate":"41153.7"`). The diagrid-dashboard step is skipped (read-only viz).
- **CI** — `ci/setup-dapr-workflow-aspire.sh` (uv, Dapr CLI, `dapr init`) + `.github/workflows/test-dapr-workflow-aspire.yml` with a fast Python-only `unit-tests` job (parser/resolver + a manifest-drift guard that validates the manifests against the real assignments) and a `build-and-run` job (.NET 10 + Aspire CLI + the suite). The pinned template install is left to the suite's Ch1 (single source of truth in the assignment), not hardcoded in CI.

**Coverage note:** rather than a separate static checker, the extractor enforces manifest coverage itself — an unmapped `,copy` block fails the run. `check_doc_sync.py` is intentionally not reused (its "command appears verbatim in the suite" model doesn't fit an extraction-based track) and is unchanged.

Design decisions are recorded in `docs/superpowers/specs/2026-07-23-dapr-workflow-aspire-drift-tests-design.md`; the task breakdown in `docs/superpowers/plans/2026-07-23-dapr-workflow-aspire-drift-tests.md`.

## Real issues the harness caught (both fixed here, in `2-project-creation/assignment.md`)

1. **Non-existent NuGet package.** The assignment installed `Dapr.Workflow.Versioning --version 1.18.4`, which doesn't exist on NuGet — that standalone package tops out at 1.18.0; the versioning APIs were folded into `Dapr.Workflow` at 1.18. Removed the standalone package line + its `<PackageReference>` echo + the prose reference. Verified the ApiService still builds and `using Dapr.Workflow.Versioning;` / `AddDaprWorkflowVersioning()` still compile from `Dapr.Workflow` 1.18.4.
2. **Invalid `launchSettings.json` env-var types.** `DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` and `ASPIRE_ALLOW_UNSECURED_TRANSPORT` were JSON booleans (`true`), but Aspire's launch-profile `environmentVariables` is a string→string map. On stricter .NET SDKs (the GitHub runner) the profile fails to deserialize → `ASPNETCORE_URLS`/OTLP endpoints never get set → the AppHost crashes on startup → the ApiService never binds `:5411`. Quoted them as `"true"` (the correct, portable form).

## Test status

- **CI green** — the `unit-tests` and `build-and-run` jobs both pass on the GitHub runner (run for HEAD), including Ch5 (`aspire run` → workflow `COMPLETED`).
- `unit-tests`: 23 pytest passing (parser, apply, manifest-drift guard).
- `challenge.robot`: 5 checkpoints — Ch1 pins `Aspire.ProjectTemplates@13.3.5` (extracted from the assignment; the version that accepts the `0.0.0.0` sandbox binding), Ch2–Ch4 build, Ch5 runs the workflow and asserts completion.
- The two fixes above were surfaced by running the suite (build/runtime), and the aspire run log is now captured into the uploaded artifact for diagnosability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
