### PR TITLE
Fix ch9 combined-patterns flakiness: wait for shipping app (.NET & Python)

### DIFF
--- a/dapr-workflow/9-combined-patterns/tests/challenge.robot
+++ b/dapr-workflow/9-combined-patterns/tests/challenge.robot
@@ -18,6 +18,10 @@ DotNet Combined Patterns
     Run And Expect RC Zero    dotnet build ShippingApp    ${WF_BASE}/csharp/combined-patterns
     Run And Expect RC Zero    dotnet build WorkflowApp    ${WF_BASE}/csharp/combined-patterns
     Start Workflow App    dapr run -f .    ${WF_BASE}/csharp/combined-patterns    ${LOG}    http://localhost:5260/
+    # Wait until the shipping app (:5261) is ready too. The workflow's first
+    # activity (CheckShippingDestination) service-invokes the shipping app, so
+    # POSTing /start before it is up returns 500 and the workflow fails immediately.
+    Wait Until App Responds    http://localhost:5261/    120s
     Run And Expect RC Zero
     ...    curl -i --request POST --url http://localhost:5260/start --header 'content-type: application/json' --data '{"id": "${ORDER_ID}","orderItem" : {"productId": "RBD001","productName": "Rubber Duck","quantity": 10,"totalPrice": 15.00},"customerInfo" : {"id" : "Customer1","country" : "The Netherlands"}}'
     Wait Until Workflow Completed    http://localhost:3560/v1.0/workflows/dapr/${ORDER_ID}    ${OUTPUT}
@@ -44,6 +48,10 @@ Python Combined Patterns
     Run And Expect RC Zero    bash -c 'source ../venv/bin/activate && pip3 install -r requirements.txt'    ${WF_BASE}/python/combined-patterns/workflow_app
     Run And Expect RC Zero    bash -c 'source ../venv/bin/activate && pip3 install -r requirements.txt'    ${WF_BASE}/python/combined-patterns/shipping_app
     Start Workflow App    bash -c 'source venv/bin/activate && dapr run -f .'    ${WF_BASE}/python/combined-patterns    ${LOG}    http://localhost:5260/
+    # Wait until the shipping app (:5261) is ready too. The workflow's first
+    # activity (CheckShippingDestination) service-invokes the shipping app, so
+    # POSTing /start before it is up returns 500 and the workflow fails immediately.
+    Wait Until App Responds    http://localhost:5261/    120s
     Run And Expect RC Zero
     ...    curl -i --request POST --url http://localhost:5260/start --header 'content-type: application/json' --data '{"id": "${ORDER_ID}","order_item" : {"product_id": "RBD001","product_name": "Rubber Duck","quantity": 10,"total_price": 15.00},"customer_info" : {"id" : "Customer1","country" : "The Netherlands"}}'
     Wait Until Workflow Completed    http://localhost:3560/v1.0/workflows/dapr/${ORDER_ID}    ${OUTPUT}


### PR DESCRIPTION
## Problem

The dapr-workflow **ch9 combined-patterns** .NET leg failed in CI: the `OrderWorkflow` went `RUNNING -> FAILED` in ~0.18s with `Task failed: Failed to register shipment. Reason: Internal Server Error.`

## Root cause — a readiness race (not track/app drift)

The error text is misleading: that exception is thrown by **`CheckShippingDestination`** (a mislabeled message upstream in dapr/quickstarts), the workflow's *first* activity. It service-invokes the `shipping` app via `DaprClient.CreateInvokeHttpClient(appId: \"shipping\")`.

Under `dapr run -f .`, `order-workflow` (:5260) and `shipping` (:5261) start together. The .NET and Python tests waited only for :5260, then immediately POSTed `/start`. When the workflow ran `CheckShippingDestination` before the `shipping` app finished cold-starting, the Dapr service invocation returned **500** and the workflow failed at once.

The **Java** leg already guards this exact race (`Wait Until App Responds http://localhost:8081/`); .NET and Python were missing the equivalent wait — hence the intermittent failures.

## Fix

Add a `Wait Until App Responds http://localhost:5261/` probe before POSTing `/start` in the .NET and Python test cases. If the shipping app ever genuinely fails to start, this now surfaces as a clear readiness timeout instead of a cryptic workflow failure.

Dry-run passes (3/3). No change to the Java leg or to assignment content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)