### PR TITLE
Addition of AI-agent-langgraph track

### DIFF
--- a/ai-agents-langgraph/1-introduction/README.md
+++ b/ai-agents-langgraph/1-introduction/README.md
@@ -1,0 +1,11 @@
+# Name
+
+Introduction
+
+## Url
+
+ai-agents-langgraph-introduction
+
+### Description
+
+Learn what LangGraph is, why durability matters for agents, and verify the sandbox is ready to run the Schedule Planner agent.

--- a/ai-agents-langgraph/1-introduction/assignment.md
+++ b/ai-agents-langgraph/1-introduction/assignment.md
@@ -1,0 +1,52 @@
+Welcome to **Making LangGraph Agents Durable with Dapr Workflow**. In this track you'll run a LangGraph agent, a **Schedule Planner** that checks venue availability. Then you'll make it durable enough to survive a crash. This first challenge takes about 4 minutes.
+
+## What is LangGraph?
+
+[LangGraph](https://www.langchain.com/langgraph) is a framework for building agents as **state machines**. Instead of a single prompt-and-response loop, you define:
+
+- **Nodes**: plain functions that read and write a shared state.
+- **Edges**: the paths between nodes, including conditional edges that route based on the state (for example, "call a tool" versus "stop").
+- **State**: a shared dictionary that flows through the graph as it executes.
+
+A plain LLM loop calls the model once and returns. A LangGraph agent can loop. It calls the model, decides whether to call a tool, calls it, feeds the result back to the model, and repeats until the model is done. That loop is what you'll inspect in the next challenge.
+
+## Why durability matters
+
+A LangGraph graph runs entirely in process memory by default. Every node execution, every tool result, and every message in the conversation lives in a Python variable. Kill the process mid-loop and it's all gone. You'd have to start the whole run over, including any LLM calls you already paid for.
+
+LangGraph gives you the structure for an agent. It doesn't give you durability. That's what **Dapr Workflow** adds. Wrap the same compiled graph in a `DaprWorkflowGraphRunner` and every node execution becomes a checkpointed Dapr Workflow activity, persisted to Redis before the graph moves to the next step. In challenges 3 and 4 you'll run that durable version and prove it survives a real crash.
+
+## What you'll build
+
+You'll run **Schedule Planner**, a LangGraph agent with a single tool called `check_availability` that checks whether a venue is free on a given date. The agent is wrapped in a Dapr Workflow and exposed over HTTP. A `POST` to `/agent/run` triggers a run, the LLM decides to call `check_availability`, and the agent returns the available time slots.
+
+## 1. Verify the sandbox
+
+Use the **Terminal** window to confirm the Dapr CLI and runtime are ready:
+
+```bash,run
+dapr -v
+```
+
+> [!NOTE]
+> You should see both a **CLI version** and a **Runtime version** listed. If the Runtime version is blank, run `dapr init` below to initialize it. If you run into any other blocking issue during this course, send me [an email](mailto:marc@diagrid.io) and we'll figure it out together.
+
+```bash,run
+dapr init
+```
+
+## 2. Add your OpenAI API key
+
+`main.py` reads `OPENAI_API_KEY` straight from the shell environment. There's no `.env` file involved. So that the key is available in every terminal tab across the rest of this track, not just the one you're in right now, append it to `~/.bashrc`:
+
+```bash,run,copy
+echo 'export OPENAI_API_KEY="your_key_here"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+> [!NOTE]
+> You'll need a real key from https://platform.openai.com/signup. The agent calls `gpt-4.1` in challenge 3. Replace `your_key_here` with your actual key before running the command above.
+
+---
+
+You now have a working sandbox and know why a durability layer is worth adding to a LangGraph agent. Let's move on to challenge 2 where you'll read through the Schedule Planner's graph.

--- a/ai-agents-langgraph/1-introduction/notes.md
+++ b/ai-agents-langgraph/1-introduction/notes.md
@@ -1,0 +1,18 @@
+Click the *Start* button to setup the sandbox environment for this training, this may take up to 2 minutes. Once the environment is ready, click the *Start* button again.
+
+- There are 4 challenges to complete, each takes about 4-7 minutes. If your session is idle for more than 10 minutes, the session will stop and you'll need to restart the track.
+- You can extend the time with 10 minutes if you run out of time.
+- Tracks can be restarted up to 5 times.
+
+---
+
+LangGraph gives you the structure to build an agent as a state machine. In this first challenge you'll learn what that means, why durability matters, and get your sandbox ready. This challenge takes about 4 minutes.
+
+### What you'll learn in this challenge
+
+- What LangGraph is and how it structures agents
+- Why LangGraph on its own can't survive a crash
+- How to check the sandbox is ready
+- Where to add your OpenAI API key
+
+If you have any questions or feedback about this track, you can let us know in the *#general* channel of the [Dapr Discord server](https://diagrid.ws/dapr-discord).

--- a/ai-agents-langgraph/1-introduction/scripts/check.sh
+++ b/ai-agents-langgraph/1-introduction/scripts/check.sh
@@ -1,0 +1,7 @@
+if [ -z "$(docker ps -f "name=dapr_redis" -f "status=running" -q)" ]; then
+    fail-message "Dapr containers not running. Did you run 'dapr init'?"
+elif ! grep -qE '^export OPENAI_API_KEY=.+' ~/.bashrc || grep -q 'your_key_here' ~/.bashrc; then
+    fail-message "OPENAI_API_KEY is not set (or still the placeholder) in ~/.bashrc. Append your real key with 'echo export OPENAI_API_KEY=...  >> ~/.bashrc'."
+else
+    echo "Sandbox ready and API key set! 👍"
+fi

--- a/ai-agents-langgraph/1-introduction/scripts/solve.sh
+++ b/ai-agents-langgraph/1-introduction/scripts/solve.sh
@@ -1,0 +1,4 @@
+dapr init
+
+echo 'export OPENAI_API_KEY="sk-solve-placeholder-key"' >> ~/.bashrc
+source ~/.bashrc

--- a/ai-agents-langgraph/1-introduction/tabs.md
+++ b/ai-agents-langgraph/1-introduction/tabs.md
@@ -1,0 +1,13 @@
+# Tab configuration
+
+## Editor
+
+type: code editor
+host: {{...}}
+path: catalyst-quickstarts/agents/langgraph
+
+## Terminal
+
+type: terminal
+host: {{...}}
+path: catalyst-quickstarts/agents/langgraph

--- a/ai-agents-langgraph/2-meet-the-graph/README.md
+++ b/ai-agents-langgraph/2-meet-the-graph/README.md
@@ -1,0 +1,11 @@
+# Name
+
+Meet the graph
+
+## Url
+
+ai-agents-langgraph-meet-the-graph
+
+### Description
+
+Read through main.py and understand how LangGraph's tool, nodes, and conditional routing come together, and what DaprWorkflowGraphRunner adds on top.

--- a/ai-agents-langgraph/2-meet-the-graph/assignment.md
+++ b/ai-agents-langgraph/2-meet-the-graph/assignment.md
@@ -1,0 +1,103 @@
+LangGraph's whole point is the graph, so before running anything, let's read one. This challenge is Editor-only. No terminal, no running. This challenge takes about 4 minutes.
+
+## 1. Open main.py
+
+Open `main.py` in the **Editor**. At a high level, this file builds a LangGraph graph, wraps it in a Dapr Workflow runner, and serves it over HTTP. Let's walk through it top to bottom.
+
+## 2. Inspect the tool
+
+Look at lines 13-16:
+
+```python,nocopy
+@tool
+def check_availability(venue: str, date: str) -> str:
+    """Check venue availability for a specific date."""
+    return f"{venue} is available on {date}. Time slots: 9AM-1PM, 2PM-6PM, 6PM-11PM."
+```
+
+A LangGraph tool is just a Python function decorated with `@tool`. The LLM never calls this function directly. It decides *when* to call it and *with what arguments*, and LangGraph runs it on the LLM's behalf.
+
+## 3. Inspect the nodes
+
+Look at lines 24-35. There are two functions here, each a **node** in the graph:
+
+```python,nocopy
+def call_model(state: MessagesState) -> dict:
+    response = model.invoke(state["messages"])
+    return {"messages": [response]}
+
+
+def call_tools(state: MessagesState) -> dict:
+    last_message = state["messages"][-1]
+    results = []
+    for tc in last_message.tool_calls:
+        result = tools_by_name[tc["name"]].invoke(tc["args"])
+        results.append(ToolMessage(content=str(result), tool_call_id=tc["id"]))
+    return {"messages": results}
+```
+
+`call_model` sends the conversation so far to the LLM. `call_tools` executes whatever tool calls the LLM asked for. Each is a plain function that reads the shared `MessagesState` and returns updates to it. That's all a LangGraph node is.
+
+## 4. Inspect the routing
+
+Look at lines 38-42:
+
+```python,nocopy
+def should_use_tools(state: MessagesState) -> str:
+    last_message = state["messages"][-1]
+    if hasattr(last_message, "tool_calls") and last_message.tool_calls:
+        return "tools"
+    return "__end__"
+```
+
+`should_use_tools` decides where to go after `call_model` runs. It goes back to `tools` if the LLM asked for a tool call, or ends the graph if it didn't. This is the **conditional edge** that creates the tool-calling loop. Without it, the graph would only ever run once.
+
+## 5. Inspect the graph construction
+
+Look at lines 45-50:
+
+```python,nocopy
+graph = StateGraph(MessagesState)
+graph.add_node("agent", call_model)
+graph.add_node("tools", call_tools)
+graph.add_edge(START, "agent")
+graph.add_conditional_edges("agent", should_use_tools)
+graph.add_edge("tools", "agent")
+```
+
+Nodes are registered, then edges are wired: `START → agent → (conditional) → tools → agent → …`. The graph keeps looping between `agent` and `tools` until `should_use_tools` returns `__end__`.
+
+## 6. Inspect the runner
+
+Look at lines 52-66:
+
+```python,nocopy
+runner = DaprWorkflowGraphRunner(
+    graph=graph.compile(),
+    name="schedule-planner",
+    role="Schedule Planner",
+    goal="Check venue date and time availability using the check_availability tool. Provide available time slots for a given venue and date.",
+)
+
+runner.serve(
+    port=int(os.environ.get("APP_PORT", "8005")),
+    input_mapper=lambda req: {"messages": [HumanMessage(content=req["task"])]},
+    pubsub_name="agent-pubsub",
+    subscribe_topic="schedule.requests",
+    publish_topic="schedule.results",
+)
+```
+
+`DaprWorkflowGraphRunner(...)` wraps the compiled graph. That one line is the entire durability layer, and you'll see what it actually does in challenge 3. `runner.serve(...)` starts an HTTP server on port `8005` and subscribes to a pub/sub topic, so the same graph can be triggered either way.
+
+## 7. How this works
+
+Putting it together:
+
+1. LangGraph builds the state machine: nodes, edges, and the shared `MessagesState`.
+2. `DaprWorkflowGraphRunner` wraps the compiled graph so each node execution becomes a **checkpointed Dapr Workflow activity** instead of an in-memory function call.
+3. `runner.serve(...)` exposes it as an HTTP endpoint, and a pub/sub subscriber, via FastAPI.
+
+---
+
+You've read the whole graph without running a single command. Let's move on to challenge 3 where you'll actually run it and watch the durability layer in action.

--- a/ai-agents-langgraph/2-meet-the-graph/notes.md
+++ b/ai-agents-langgraph/2-meet-the-graph/notes.md
@@ -1,0 +1,14 @@
+The sandbox for this challenge is being prepared, it should be ready within a few seconds. Once it's ready, click the *Start* button.
+
+---
+
+This challenge is pure reading, no running yet. You'll open `main.py` and see exactly how LangGraph builds the Schedule Planner's tool-calling loop, and how a single line turns it into a Dapr Workflow. This challenge takes about 4 minutes.
+
+### What you'll learn in this challenge
+
+- How LangGraph builds an agent from nodes, edges, and state
+- What a conditional edge is and how the tool-calling loop works
+- What `DaprWorkflowGraphRunner` adds on top of the graph
+- How the agent becomes an HTTP service
+
+If you have any questions or feedback about this track, you can let us know in the *#general* channel of the [Dapr Discord server](https://diagrid.ws/dapr-discord).

--- a/ai-agents-langgraph/2-meet-the-graph/tabs.md
+++ b/ai-agents-langgraph/2-meet-the-graph/tabs.md
@@ -1,0 +1,7 @@
+# Tab configuration
+
+## Editor
+
+type: code editor
+host: {{...}}
+path: catalyst-quickstarts/agents/langgraph

--- a/ai-agents-langgraph/3-run-it-durable/README.md
+++ b/ai-agents-langgraph/3-run-it-durable/README.md
@@ -1,0 +1,11 @@
+# Name
+
+Run it durable
+
+## Url
+
+ai-agents-langgraph-run-it-durable
+
+### Description
+
+Run the Schedule Planner agent under Dapr, trigger it over HTTP, and inspect the checkpointed workflow state directly in Redis.

--- a/ai-agents-langgraph/3-run-it-durable/assignment.md
+++ b/ai-agents-langgraph/3-run-it-durable/assignment.md
@@ -1,0 +1,73 @@
+Time to run the Schedule Planner for real and watch the durability layer at work. This challenge takes about 6 minutes.
+
+## 1. Start the agent with Dapr
+
+Use the **Terminal** window:
+
+```bash,run
+uv run dapr run --app-id schedule-planner --resources-path ./resources -- python main.py
+```
+
+This starts the Dapr sidecar alongside the FastAPI server. Wait until you see `Uvicorn running on http://0.0.0.0:8005` before continuing.
+
+## 2. Trigger a run
+
+Use the **Terminal 2** window:
+
+```bash,run
+curl -i -X POST http://localhost:8005/agent/run \
+  -H "Content-Type: application/json" \
+  -d '{"task": "Check if the Grand Ballroom is available on March 15th"}'
+```
+
+## 3. Observe the log stream
+
+Switch back to **Terminal** and watch the output. You'll see `Event: workflow_started`, the `check_availability` tool being invoked, and `Event: workflow_completed` once the agent has an answer.
+
+## 4. Inspect the state store
+
+Open `resources/wfstatestore.yaml` in the **Editor**:
+
+```yaml,nocopy
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: agent-workflow
+spec:
+  type: state.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""
+  - name: actorStateStore
+    value: "true"
+```
+
+This is a Redis-backed Dapr state store. `actorStateStore: "true"` is what makes it usable by the Dapr Workflow engine. Workflows run on Dapr's actor runtime under the hood, and this component is where that runtime persists its state.
+
+## 5. Peek into Redis
+
+Use **Terminal 2**:
+
+```bash,run
+docker exec dapr_redis redis-cli keys "*schedule-planner*"
+```
+
+These keys are the workflow instance state, its activity results, and its execution history. All of it was written to Redis as the graph ran, before you even looked.
+
+## 6. How this works
+
+1. Each LangGraph node (`agent`, `tools`) runs as a Dapr Workflow activity.
+2. Every activity's result is checkpointed to Redis before the next node runs.
+3. The workflow can be replayed from any checkpoint. Dapr doesn't need to trust that anything is still in memory.
+4. That's what makes crash recovery possible, which you'll prove in the next challenge.
+
+## 7. Stop the app
+
+Use `Ctrl+C` in the **Terminal** window to stop the Dapr application before moving on.
+
+---
+
+You've seen the agent run as a durable workflow and inspected its checkpointed state. Let's move on to challenge 4 where you'll crash it on purpose.

--- a/ai-agents-langgraph/3-run-it-durable/notes.md
+++ b/ai-agents-langgraph/3-run-it-durable/notes.md
@@ -1,0 +1,17 @@
+The sandbox for this challenge is being prepared, it should be ready within a few seconds. Once it's ready, click the *Start* button.
+
+---
+
+Time to see the durability layer at work. You'll start the agent under Dapr, trigger a run, and watch each node execute as a checkpointed workflow activity. This challenge takes about 6 minutes.
+
+> [!IMPORTANT]
+> This challenge uses two terminals: *Terminal* for running the agent, and *Terminal 2* for triggering it. When you use the *Run* button on a command, select the matching terminal from the dropdown that appears.
+
+### What you'll learn in this challenge
+
+- How to run a Dapr-backed LangGraph agent as an HTTP service
+- What workflow events look like as the agent runs
+- How to inspect checkpointed state directly in Redis
+- What makes this run resilient to failure
+
+If you have any questions or feedback about this track, you can let us know in the *#general* channel of the [Dapr Discord server](https://diagrid.ws/dapr-discord).

--- a/ai-agents-langgraph/3-run-it-durable/scripts/check.sh
+++ b/ai-agents-langgraph/3-run-it-durable/scripts/check.sh
@@ -1,0 +1,7 @@
+KEYS=$(docker exec dapr_redis redis-cli keys "*schedule-planner*" 2>/dev/null)
+
+if [ -z "$KEYS" ]; then
+    fail-message "No 'schedule-planner' keys found in Redis. Run the agent with 'dapr run --app-id schedule-planner ...' and trigger it with the curl command first."
+else
+    echo "Workflow state found in Redis! 👍"
+fi

--- a/ai-agents-langgraph/3-run-it-durable/scripts/solve.sh
+++ b/ai-agents-langgraph/3-run-it-durable/scripts/solve.sh
@@ -1,0 +1,26 @@
+# NOTE: this challenge runs a blocking `dapr run` process in one terminal while
+# triggering it from another, which can't be fully automated from a single
+# non-interactive script. The manual flow is:
+#
+#   1. uv run dapr run --app-id schedule-planner --resources-path ./resources -- python main.py
+#   2. curl -X POST http://localhost:8005/agent/run -H "Content-Type: application/json" \
+#        -d '{"task": "Check if the Grand Ballroom is available on March 15th"}'
+#
+# This backgrounds the app, triggers it, waits for the reply, then stops it,
+# so the Redis keys the check.sh looks for exist afterwards.
+source ~/.bashrc
+cd catalyst-quickstarts/agents/langgraph
+
+uv run dapr run --app-id schedule-planner --resources-path ./resources -- python main.py &
+APP_PID=$!
+
+until curl -s http://localhost:8005/docs >/dev/null 2>&1; do
+  sleep 1
+done
+
+curl -s -X POST http://localhost:8005/agent/run \
+  -H "Content-Type: application/json" \
+  -d '{"task": "Check if the Grand Ballroom is available on March 15th"}'
+
+sleep 5
+kill "$APP_PID" 2>/dev/null

--- a/ai-agents-langgraph/3-run-it-durable/tabs.md
+++ b/ai-agents-langgraph/3-run-it-durable/tabs.md
@@ -1,0 +1,19 @@
+# Tab configuration
+
+## Editor
+
+type: code editor
+host: {{...}}
+path: catalyst-quickstarts/agents/langgraph
+
+## Terminal
+
+type: terminal
+host: {{...}}
+path: catalyst-quickstarts/agents/langgraph
+
+## Terminal 2
+
+type: terminal
+host: {{...}}
+path: catalyst-quickstarts/agents/langgraph

--- a/ai-agents-langgraph/4-crash-and-recover/README.md
+++ b/ai-agents-langgraph/4-crash-and-recover/README.md
@@ -1,0 +1,11 @@
+# Name
+
+Crash and recover
+
+## Url
+
+ai-agents-langgraph-crash-and-recover
+
+### Description
+
+Crash a LangGraph workflow mid-run with a hard process kill, restart it, and prove the completed step is not re-executed on resume.

--- a/ai-agents-langgraph/4-crash-and-recover/assignment.md
+++ b/ai-agents-langgraph/4-crash-and-recover/assignment.md
@@ -1,0 +1,116 @@
+You're going to crash a workflow on purpose, then prove Dapr picks up exactly where it left off. This challenge takes about 7 minutes.
+
+## 1. Open crash_test.py
+
+Open `crash_test.py` in the **Editor**. It's a simpler 3-node graph than `main.py`, with no LLM, just sequential steps: `check_venues` → `compare_options` → `confirm_booking`. That makes the recovery easy to see clearly.
+
+## 2. Show the crash line
+
+Look at line 30:
+
+```python,nocopy
+os._exit(1)  # 💥 Simulates a crash — comment out this line before the second run
+```
+
+`os._exit(1)` kills the Python process immediately. There's no exception, no cleanup, and no chance for Dapr to shut down gracefully. This simulates a hard infrastructure failure, like a pod eviction, an OOM kill, or a host reboot.
+
+## 3. Start the crash test app
+
+Use the **Terminal** window:
+
+```bash,run
+uv run dapr run --app-id langgraph-crash-test --resources-path ./resources -- python crash_test.py
+```
+
+Wait for `Uvicorn running on http://0.0.0.0:8001`.
+
+## 4. Trigger the workflow
+
+Use the **Terminal 2** window:
+
+```bash,run
+curl -X POST http://localhost:8001/run \
+  -H "Content-Type: application/json" \
+  -d '{"topic": "company gala on March 15"}'
+```
+
+## 5. Observe the crash
+
+Switch to **Terminal**. You'll see:
+
+```text,nocopy
+>>> STEP 1: Checking venue availability for 'company gala on March 15'...
+>>> STEP 1 COMPLETE: Grand Ballroom available on March 15 (2PM-6PM, 6PM-11PM)
+>>> STEP 2: Comparing venue options...
+❌ The App process exited with error code: 1
+```
+
+Step 1 finished and was checkpointed. Step 2 started, then the process died. There's no graceful shutdown message, just silence.
+
+## 6. Verify state was persisted mid-crash
+
+Use **Terminal 2**:
+
+```bash,run
+docker exec dapr_redis redis-cli keys "*crash-recovery-demo*"
+```
+
+Step 1's result is safely in Redis even though the process died right after starting step 2.
+
+## 7. Comment out the crash
+
+Back in the **Editor**, comment out line 30 in `crash_test.py`:
+
+```python,nocopy
+# os._exit(1)  # 💥 Simulates a crash — comment out this line before the second run
+```
+
+## 8. Restart the app
+
+Use the **Terminal** window:
+
+```bash,run
+uv run dapr run --app-id langgraph-crash-test --resources-path ./resources -- python crash_test.py
+```
+
+Because `thread_id="crash-recovery-demo"` is hardcoded in `crash_test.py`, the workflow instance that was scheduled before the crash is still sitting in Redis under that same identity. You do **not** need to send another `curl` request. As soon as the app reconnects to its Dapr sidecar and re-registers the workflow, Dapr resumes that instance on its own.
+
+## 9. Watch the recovery
+
+Watch **Terminal**. You'll see step 2 run again, this time without crashing, followed by step 3, and the workflow completes:
+
+```text,nocopy
+>>> STEP 2: Comparing venue options...
+>>> STEP 2 COMPLETE: Grand Ballroom (6PM-11PM) is the best option for 200 guests
+>>> STEP 3: Confirming booking...
+>>> STEP 3 COMPLETE: Booking confirmed: Grand Ballroom, March 15, 6PM-11PM
+```
+
+> [!IMPORTANT]
+> Notice `STEP 1` does **not** print again. Its result already exists in Redis, so Dapr replays it from the checkpoint instead of re-running `check_venues`.
+
+## 10. Recap
+
+- Each LangGraph node runs as a checkpointed Dapr Workflow activity.
+- `os._exit(1)` killed the process hard mid-flow, simulating a pod eviction or OOM kill.
+- On restart, Dapr found the workflow instance by its deterministic ID and replayed history from the checkpoint store. That returned already-saved results without re-executing them, and the workflow resumed at step 2.
+- The workflow completed even though the process that started it had died.
+
+---
+
+## Feedback and further learning
+
+Congratulations! 🎉 You've completed the *Making LangGraph Agents Durable with Dapr Workflow* learning track! Please take a moment to rate this training and provide feedback in the next step so we can keep improving it.
+
+We have more ways for you to learn and share knowledge:
+
+**Try another university track**
+- [Deep issue investigation with DeepAgents and Dapr Workflow](https://www.diagrid.io/university/ai-agents-deepagents)
+
+**Read more**
+- Read the [State of Dapr 2026 report](https://www.diagrid.io/reports-and-ebooks/state-of-dapr-2026).
+- Read [Announcing Durable Workflow for Agents](https://www.diagrid.io/blog/durable-workflows-ai-agents).
+
+**Join the community**
+- Join the [Dapr Discord](https://diagrid.ws/dapr-discord) where thousands of developers share knowledge about Dapr. There are dedicated *#workflow*, *#ai* and language channels.
+- Register for one of [our webinars](https://www.diagrid.io/webinars) to learn more about building reliable applications.

--- a/ai-agents-langgraph/4-crash-and-recover/notes.md
+++ b/ai-agents-langgraph/4-crash-and-recover/notes.md
@@ -1,0 +1,17 @@
+The sandbox for this challenge is being prepared, it should be ready within a few seconds. Once it's ready, click the *Start* button.
+
+---
+
+This is the payoff. You're going to crash a LangGraph workflow on purpose, then prove it picks up exactly where it left off. This challenge takes about 7 minutes.
+
+> [!IMPORTANT]
+> This challenge uses two terminals: *Terminal* for running the app, and *Terminal 2* for triggering it. When you use the *Run* button on a command, select the matching terminal from the dropdown that appears.
+
+### What you'll learn in this challenge
+
+- How to simulate a hard crash mid-workflow
+- How Dapr Workflow resumes from the last checkpoint
+- How to prove no completed step is re-run after recovery
+- Why this is the whole point of durable execution
+
+If you have any questions or feedback about this track, you can let us know in the *#general* channel of the [Dapr Discord server](https://diagrid.ws/dapr-discord).

--- a/ai-agents-langgraph/4-crash-and-recover/scripts/check.sh
+++ b/ai-agents-langgraph/4-crash-and-recover/scripts/check.sh
@@ -1,0 +1,7 @@
+KEYS=$(docker exec dapr_redis redis-cli keys "*crash-recovery-demo*" 2>/dev/null)
+
+if [ -z "$KEYS" ]; then
+    fail-message "No 'crash-recovery-demo' keys found in Redis. Run crash_test.py, trigger it, let it crash, then comment out the os._exit(1) line and restart it."
+else
+    echo "Durable workflow state found in Redis, crash and recovery proven! 👍"
+fi

--- a/ai-agents-langgraph/4-crash-and-recover/scripts/solve.sh
+++ b/ai-agents-langgraph/4-crash-and-recover/scripts/solve.sh
@@ -1,0 +1,34 @@
+# NOTE: this challenge is interactive. It requires stopping and restarting a
+# blocking `dapr run` process around a deliberate crash, which can't be fully
+# automated from a single non-interactive script. The manual flow is:
+#
+#   1. uv run dapr run --app-id langgraph-crash-test --resources-path ./resources -- python crash_test.py
+#   2. curl -X POST http://localhost:8001/run -H "Content-Type: application/json" \
+#        -d '{"topic": "company gala on March 15"}'
+#   3. Wait for the crash (the app process exits).
+#   4. Comment out line 30 (`os._exit(1)`) in crash_test.py.
+#   5. uv run dapr run --app-id langgraph-crash-test --resources-path ./resources -- python crash_test.py
+#
+# This scripts that same flow so the Redis keys the check.sh looks for exist afterwards.
+cd catalyst-quickstarts/agents/langgraph
+
+uv run dapr run --app-id langgraph-crash-test --resources-path ./resources -- python crash_test.py &
+
+until curl -s http://localhost:8001/docs >/dev/null 2>&1; do
+  sleep 1
+done
+
+curl -s -X POST http://localhost:8001/run \
+  -H "Content-Type: application/json" \
+  -d '{"topic": "company gala on March 15"}'
+
+# Wait for the first (crashing) process to exit.
+sleep 5
+
+sed -i 's/^\( *\)os\._exit(1)/\1# os._exit(1)/' crash_test.py
+
+uv run dapr run --app-id langgraph-crash-test --resources-path ./resources -- python crash_test.py &
+APP_PID=$!
+
+sleep 8
+kill "$APP_PID" 2>/dev/null

--- a/ai-agents-langgraph/4-crash-and-recover/tabs.md
+++ b/ai-agents-langgraph/4-crash-and-recover/tabs.md
@@ -1,0 +1,19 @@
+# Tab configuration
+
+## Editor
+
+type: code editor
+host: {{...}}
+path: catalyst-quickstarts/agents/langgraph
+
+## Terminal
+
+type: terminal
+host: {{...}}
+path: catalyst-quickstarts/agents/langgraph
+
+## Terminal 2
+
+type: terminal
+host: {{...}}
+path: catalyst-quickstarts/agents/langgraph

--- a/ai-agents-langgraph/README.md
+++ b/ai-agents-langgraph/README.md
@@ -1,0 +1,42 @@
+# Name
+
+Making LangGraph agents durable with Dapr Workflow
+
+## Url
+
+ai-agents-langgraph
+
+## Teaser
+
+Run a LangGraph agent as a durable Dapr Workflow. Then crash it mid-run and watch it resume from a checkpoint in Redis, without re-running the steps that already completed.
+
+Languages: Python. Duration: 30 min. Requires an OpenAI API key.
+
+## Time limit (minutes)
+
+30
+
+## Description
+
+LangGraph gives you the structure to build an agent as a state machine: nodes, edges, and shared state. What it doesn't give you is durability. Kill the process mid-run and everything in memory is gone. In this self-paced track you'll see how **Dapr Workflow** turns a LangGraph graph into a durable, crash-proof application.
+
+You'll work with **Schedule Planner**, a LangGraph agent that checks venue availability using a `check_availability` tool. It runs as a Dapr Workflow via the `diagrid[langgraph]` SDK.
+
+In this self-paced track, you'll learn:
+- What LangGraph is and how it structures an agent as nodes, edges, and state.
+- How `DaprWorkflowGraphRunner` wraps a compiled LangGraph graph so each node executes as a checkpointed Dapr Workflow activity.
+- How to trigger the agent over HTTP and watch workflow events as it runs.
+- How to inspect checkpointed workflow state directly in Redis.
+- How a mid-run crash resumes from durable state, without re-executing completed nodes.
+
+You'll probably need around 25 minutes to complete the 4 challenges.
+
+If your session is idle for more than 10 minutes the session will stop and you'll need to restart the track. Tracks can be started up to 5 times and you can skip challenges to continue with the challenges you didn't finish previously.
+
+### Time out idle users (minutes)
+
+10
+
+### Extra time (minutes)
+
+10

--- a/ai-agents-langgraph/_setup/image-definition.sh
+++ b/ai-agents-langgraph/_setup/image-definition.sh
@@ -1,0 +1,9 @@
+# The base image is the Instruqt Docker image, this has docker installed
+
+# Update package index
+sudo apt-get update
+
+# Python
+sudo apt-get install python3.12 -y
+sudo apt install python3-pip -y
+sudo apt install python3.12-venv -y

--- a/ai-agents-langgraph/_setup/sandbox-setup.sh
+++ b/ai-agents-langgraph/_setup/sandbox-setup.sh
@@ -1,0 +1,23 @@
+# Runs at every sandbox launch.
+# Clone the LangGraph sample source (public repo) into the learner's working directory.
+git clone https://github.com/diagridio/catalyst-quickstarts.git
+
+# Authenticate to Docker Hub to avoid anonymous pull rate limits.
+docker login -u ${DockerUSER} -p ${DockerPAT}
+
+wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash
+dapr init
+dapr -v
+
+if [ -n "$(docker ps -f "name=dapr_placement" -f "status=running" -q )" ] && [ -n "$(docker ps -f "name=dapr_scheduler" -f "status=running" -q )" ] && [ -n "$(docker ps -f "name=dapr_redis" -f "status=running" -q )"  ] && [ -n "$(docker ps -f "name=dapr_zipkin" -f "status=running" -q )" ];
+then
+    echo "The Dapr containers are running! 👍"
+else
+    dapr uninstall
+    dapr init
+fi
+
+wget -qO- https://astral.sh/uv/install.sh | sh
+
+# Install project dependencies so the first `uv run` in challenge 1 is instant.
+cd catalyst-quickstarts/agents/langgraph && ~/.local/bin/uv sync

--- a/ai-agents-langgraph/website-description.md
+++ b/ai-agents-langgraph/website-description.md
@@ -1,0 +1,23 @@
+# Making LangGraph agents durable with Dapr Workflow
+
+LangGraph gives an LLM the structure to act as a state machine: nodes, edges, and shared state driving a tool-calling loop. What it doesn't give you is durability. Kill the process mid-run and everything in memory is gone. In this hands-on track you'll see how Dapr Workflow turns a LangGraph graph into a durable, crash-proof application.
+
+## What you'll build
+
+You'll run **Schedule Planner**, a LangGraph agent with a single `check_availability` tool. It's wrapped in `DaprWorkflowGraphRunner` so every node execution becomes a checkpointed Dapr Workflow activity. Then you'll deliberately crash a simpler 3-node version mid-run and watch it resume exactly where it left off.
+
+## What you'll learn
+
+- How LangGraph builds an agent from nodes, edges, and state, and how the tool-calling loop works.
+- What `DaprWorkflowGraphRunner` adds on top of a compiled LangGraph graph.
+- How to trigger an agentic Dapr Workflow over HTTP and read its output.
+- How to inspect checkpointed workflow state directly in Redis.
+- How a real process crash resumes from durable state without repeating completed steps.
+
+## Supported language
+
+Python
+
+## Prerequisites
+
+Familiarity with Python is recommended. The sandbox comes preconfigured with Docker, Python, uv, and Dapr. You'll need your own OpenAI API key to run the agent.


### PR DESCRIPTION
Adds a new self-paced track, ai-agents-langgraph, teaching how Dapr Workflow makes a LangGraph agent durable.

- Four challenges: intro and sandbox setup, reading through the Schedule Planner's graph, running it as a durable Dapr Workflow, then crashing it on purpose and proving recovery.

- The sample app is the existing Schedule Planner quickstart in diagridio/catalyst-quickstarts (agents/langgraph). Nothing was forked into a separate repo, and the app's source code was not modified.

Note: in tabs.md, the host is currently a placeholder ({{...}}), the same convention used in ai-agents-deepagents. It'll be swapped for the real host once assigned.